### PR TITLE
[WR-1386] refresh page to correctly display saved profile counts

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/services/authentication.service.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/services/authentication.service.ts
@@ -90,8 +90,8 @@ export class AuthenticationService {
           //take the user back to the career page
           const profileIds = tmpCareerProfile.split(','); //check when there are multiple id's in the string
 
-          //use the last ID as the profile ID when redirecting
-          //window.location.href = window.location.origin + '/Jobs-Careers/Explore-Careers/Browse-Career-Profile/' + profileIds[profileIds.length -1];
+          // reload the page to update the total number of career profiles saved
+          window.location.reload();
         });
     }
   }
@@ -116,8 +116,8 @@ export class AuthenticationService {
             this.storageService.tmpIndustryProfileUrlKey
           );
 
-          //take the user back to the industry page
-          //window.location.href = url;
+          // reload the page to update the total number of industry profiles saved
+          window.location.reload();
         });
     }
   }


### PR DESCRIPTION
Refresh page to correctly display saved profile counts when the user has saved a profile (Career or Industry) while offline.  

This is my first time creating a PR on this code base so review carefully.  Specifically, it appears as if the Angular code is built during deployment (as it should).