### PR TITLE
[WBCAMS-113] date range queries include end date

### DIFF
--- a/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
+++ b/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
@@ -34,6 +34,10 @@ namespace WorkBC.ElasticSearch.Search.Queries
             _configuration = configuration;
             _filters = filters;
             _geocodingService = geocodingService;
+            
+            // Apply filter logic 
+            SetSortFilters();
+            SetFilters();
         }
 
         #endregion
@@ -146,9 +150,8 @@ namespace WorkBC.ElasticSearch.Search.Queries
         /// <summary>
         ///     Build JSON string that will be used to query Elastic Search
         /// </summary>
-        public async Task<string> ToJson(IConfiguration configuration, string jsonFileName)
+        public async Task<string> ToJson(IConfiguration configuration, string json)
         {
-            string json = ResourceFileHelper.ReadFile(jsonFileName);
             var filterGroups = new List<string>();
             GeocodedLocationCache geoLocation = null;
 
@@ -815,11 +818,8 @@ namespace WorkBC.ElasticSearch.Search.Queries
 
             string url = $"{server}/{index}/{docType}/_search";
 
-            // Apply filter logic 
-            SetSortFilters();
-            SetFilters();
-
-            string json = await ToJson(_configuration, jsonFileName);
+            string jsonTemplate = ResourceFileHelper.ReadFile(jsonFileName);
+            string json = await ToJson(_configuration, jsonTemplate);
 
             string jsonResult = await new ElasticHttpHelper(_configuration).QueryElasticSearch(json, url);
             return JsonConvert.DeserializeObject<ElasticSearchResponse>(jsonResult);

--- a/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
+++ b/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
@@ -864,7 +864,7 @@ namespace WorkBC.ElasticSearch.Search.Queries
 
                     if (_filters.EndDate != null && _filters.EndDate.Year > 0)
                     {
-                        // set the time component to the very end-of-day so
+                        // set the time component to the end-of-day so
                         // the search includes jobs posted on the EndDate
                         _filters.EndDate.Hour = 23;
                         _filters.EndDate.Minute = 59;

--- a/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
+++ b/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
@@ -862,10 +862,20 @@ namespace WorkBC.ElasticSearch.Search.Queries
                         ? _filters.StartDate.ToString()
                         : "1970-01-01";
 
-                    EndDate = _filters.EndDate != null && _filters.EndDate.Year > 0
-                        ? _filters.EndDate.ToString()
-                        : DateTime.MaxValue.ToString("yyyy-MM-dd");
-
+                    if (_filters.EndDate != null && _filters.EndDate.Year > 0)
+                    {
+                        // set the time component to the very end-of-day so
+                        // the search includes jobs posted on the EndDate
+                        _filters.EndDate.Hour = 23;
+                        _filters.EndDate.Minute = 59;
+                        _filters.EndDate.Second = 59;
+                        _filters.EndDate.Millisecond = 999;
+                        EndDate = _filters.EndDate.ToString();
+                    }
+                    else
+                    {
+                        EndDate = DateTime.MaxValue.ToString("yyyy-MM-dd");
+                    }
                     break;
             }
 

--- a/src/WorkBC.Tests/Tests/JobSearchQueryTest.cs
+++ b/src/WorkBC.Tests/Tests/JobSearchQueryTest.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using WorkBC.ElasticSearch.Models.Filters;
+using WorkBC.ElasticSearch.Search.Queries;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using WorkBC.Shared.Services;
+using WorkBC.Tests.FakeServices;
+using Xunit;
+
+namespace WorkBC.Tests.Tests;
+
+public class JobSearchQueryTest
+{
+    // properties
+    protected readonly IConfiguration Configuration;
+    protected readonly IGeocodingService FakeGeocodingService;
+    protected readonly string JsonTemplate;
+    protected JobSearchFilters Filters; 
+
+    
+    private readonly DateField _testDate = new DateField
+    {
+        Year = 2023,
+        Month = 09,
+        Day = 28
+    };
+    
+    // constructor
+    public JobSearchQueryTest()
+    {
+        FakeGeocodingService = new FakeGeocodingService(Configuration);
+        var projectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.Parent.FullName;
+        var jsonPath = "/WorkBC.ElasticSearch.Search/Resources/jobsearch_main.json";
+        JsonTemplate = File.ReadAllText(projectDirectory + jsonPath);
+        Filters = new JobSearchFilters();
+        Filters.Page = 1;
+        Filters.PageSize = 20;
+        
+    }
+    
+    [Fact(DisplayName = "User can search jobs by posted date range that includes both the staring and ending dates")]
+    public async Task CreateJobSearchFilterForSinglePostDateRange()
+    {
+        Filters.SearchDateSelection = "3";
+        Filters.EndDate = _testDate;
+        Filters.StartDate = _testDate;
+
+        var expectedJson = @"{ ""DatePosted"": { ""gte"": ""2023-09-28T00:00:00.000"", ""lte"": ""2023-09-28T23:59:59.999"", ""time_zone"": ""America/Vancouver"" }";
+        
+        var query = new JobSearchQuery(FakeGeocodingService, Configuration, Filters);
+        var results = await query.ToJson(Configuration, JsonTemplate);
+        Assert.Contains(expectedJson, results);
+    }
+    
+    [Fact(DisplayName = "If user doesn't supply a starting and ending dates for job search query, API assumes max values")]
+    public async Task CreateJobSerchQueryUsingMaxValuesWithNoStartingAndEndingValues()
+    {
+        Filters.SearchDateSelection = "3";
+
+        var expectedJson = @"{ ""DatePosted"": { ""gte"": ""1970-01-01"", ""lte"": ""9999-12-31"", ""time_zone"": ""America/Vancouver"" }";
+        
+        var query = new JobSearchQuery(FakeGeocodingService, Configuration, Filters);
+        var results = await query.ToJson(Configuration, JsonTemplate);
+        Assert.Contains(expectedJson, results);
+    }
+    
+    [Fact(DisplayName = "User can search for jobs by today's posted date")]
+    public async Task CreateJobSearchFilterForToday()
+    {
+        Filters.SearchDateSelection = "1";
+
+        var expectedJson = @"{ ""DatePosted"": { ""gte"": ""now/d"", ""lt"": ""now+1d/d"", ""time_zone"": ""America/Vancouver"" }";
+        
+        var query = new JobSearchQuery(FakeGeocodingService, Configuration, Filters);
+        var results = await query.ToJson(Configuration, JsonTemplate);
+        Assert.Contains(expectedJson, results);
+    }
+
+
+    [Fact(DisplayName = "User cannot search for jobs using SearchDateSelection = 0")]
+    public async Task CreateJobSearchFilterUsingSearchDateSelectionEqualZero()
+    {
+        Filters.SearchDateSelection = "0";
+
+        var notExpectedJson = @"{ ""DatePosted"": { ";
+
+
+        var query = new JobSearchQuery(FakeGeocodingService, Configuration, Filters);
+        var results = await query.ToJson(Configuration, JsonTemplate);
+        Assert.DoesNotContain(notExpectedJson, results);
+    }
+    
+    [Fact(DisplayName = "User can search for jobs posted in the last 3 days")]
+    public async Task CreateJobSearchFilterForPastThreeDays()
+    {
+        Filters.SearchDateSelection = "2";
+
+        var expectedJson = @"{ ""DatePosted"": { ""gte"": ""now-3d/d"", ""lte"": ""now"", ""time_zone"": ""America/Vancouver"" }";
+        
+        var query = new JobSearchQuery(FakeGeocodingService, Configuration, Filters);
+        var results = await query.ToJson(Configuration, JsonTemplate);
+        Assert.Contains(expectedJson, results);
+    }
+   
+}

--- a/src/WorkBC.Tests/Tests/JobSearchQueryTest.cs
+++ b/src/WorkBC.Tests/Tests/JobSearchQueryTest.cs
@@ -39,7 +39,7 @@ public class JobSearchQueryTest
         
     }
     
-    [Fact(DisplayName = "User can search jobs by posted date range that includes both the staring and ending dates")]
+    [Fact(DisplayName = "User can search jobs by posted date range that includes both the starting and ending dates")]
     public async Task CreateJobSearchFilterForSinglePostDateRange()
     {
         Filters.SearchDateSelection = "3";

--- a/src/WorkBC.Tests/Tests/JobSearchQueryTest.cs
+++ b/src/WorkBC.Tests/Tests/JobSearchQueryTest.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using WorkBC.ElasticSearch.Models.Filters;
 using WorkBC.ElasticSearch.Search.Queries;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
 using WorkBC.Shared.Services;
 using WorkBC.Tests.FakeServices;
 using Xunit;


### PR DESCRIPTION
# Hold, do not merge until production deployments are complete.

Modify API so custom job board queries that filter based on PostedDate include the ending date too.  Refactor to make code more testable.