### PR TITLE
[WBCAMS-200] add interface for geocoding api class

### DIFF
--- a/src/WorkBC.Shared/Services/GeocodingCachingService.cs
+++ b/src/WorkBC.Shared/Services/GeocodingCachingService.cs
@@ -10,10 +10,10 @@ namespace WorkBC.Shared.Services
     {
         private readonly JobBoardContext _dbContext;
         private readonly ILogger<IGeocodingService> _logger;
-        private readonly IGeocodingService _geocodingService;
+        private readonly IGeocodingApiService _geocodingService;
 
         // constructor
-        public GeocodingCachingService(JobBoardContext dbContext, IGeocodingService geocodingService,
+        public GeocodingCachingService(JobBoardContext dbContext, IGeocodingApiService geocodingService,
             ILogger<IGeocodingService> logger = null)
         {
             _dbContext = dbContext;

--- a/src/WorkBC.Shared/Services/GeocodingService.cs
+++ b/src/WorkBC.Shared/Services/GeocodingService.cs
@@ -11,7 +11,7 @@ using WorkBC.Shared.Settings;
 
 namespace WorkBC.Shared.Services
 {
-    public class GeocodingService : IGeocodingService
+    public class GeocodingService : IGeocodingApiService
     {
         private readonly ILogger<IGeocodingService> _logger;
         private readonly IConfiguration _configuration;

--- a/src/WorkBC.Shared/Services/IGeocodingService.cs
+++ b/src/WorkBC.Shared/Services/IGeocodingService.cs
@@ -1,9 +1,13 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 using WorkBC.Data.Model.JobBoard;
 
 namespace WorkBC.Shared.Services
 {
+    public interface IGeocodingApiService : IGeocodingService
+    {
+        // deliberately empty
+    }
+    
     public interface IGeocodingService
     {
         Task<GeocodedLocationCache> GetLocation(string location);

--- a/src/WorkBC.Tests/FakeServices/FakeGeocodingService.cs
+++ b/src/WorkBC.Tests/FakeServices/FakeGeocodingService.cs
@@ -6,7 +6,7 @@ using WorkBC.Shared.Services;
 
 namespace WorkBC.Tests.FakeServices
 {
-    public class FakeGeocodingService : IGeocodingService
+    public class FakeGeocodingService : IGeocodingApiService
     {
         private readonly IConfiguration _configuration;
 

--- a/src/WorkBC.Tests/Tests/GeocodingServiceTests.cs
+++ b/src/WorkBC.Tests/Tests/GeocodingServiceTests.cs
@@ -17,7 +17,7 @@ namespace WorkBC.Tests.Tests
     {
         //Properties
         private readonly GeocodingCachingService _geocodingCachingService;
-        private IGeocodingService _geocodingService;
+        private IGeocodingApiService _geocodingService;
         private JobBoardContext _dbContext;
         private readonly GeocodedLocationCache _deltaLowercase = new GeocodedLocationCache
         {
@@ -84,7 +84,7 @@ namespace WorkBC.Tests.Tests
         [Fact(DisplayName = "Location names are matched to the cache using using a case-insensitive comparison")]
         public async Task LocationNamesAreMatchedUsingUppercase()
         {
-            var mockGeoService = new Mock<IGeocodingService>();
+            var mockGeoService = new Mock<IGeocodingApiService>();
             var localCachingService = new GeocodingCachingService(_dbContext, mockGeoService.Object);
             await localCachingService.SetLocation(_deltaLowercase);
             var result = await localCachingService.GetLocation("Delta, BC");

--- a/src/WorkBC.Web/Startup.cs
+++ b/src/WorkBC.Web/Startup.cs
@@ -183,7 +183,9 @@ namespace WorkBC.Web
             services.AddScoped<ISecurityQuestionService, SecurityQuestionService>();
             services.AddScoped<ILocationService, LocationService>();
             services.AddScoped<ILogger<IGeocodingService>, Logger<IGeocodingService>>();
+            services.AddScoped<IGeocodingApiService, GeocodingService>();
             services.AddScoped<IGeocodingService, GeocodingCachingService>();
+            
             services.AddScoped<INocSearchService, NocSearchService>();
             services.AddScoped<ISavedJobsService, SavedJobsService>();
             services.AddScoped<IRecommendedJobsService, RecommendedJobsService>();

--- a/src/WorkBC.Web/Startup.cs
+++ b/src/WorkBC.Web/Startup.cs
@@ -185,7 +185,6 @@ namespace WorkBC.Web
             services.AddScoped<ILogger<IGeocodingService>, Logger<IGeocodingService>>();
             services.AddScoped<IGeocodingApiService, GeocodingService>();
             services.AddScoped<IGeocodingService, GeocodingCachingService>();
-            
             services.AddScoped<INocSearchService, NocSearchService>();
             services.AddScoped<ISavedJobsService, SavedJobsService>();
             services.AddScoped<IRecommendedJobsService, RecommendedJobsService>();


### PR DESCRIPTION
This pull request should fix the issue that caused the build failure on Thursday / Friday.  I had inadvertently created a circular dependency.  Now, we're using two interfaces -- one for the API (base) class and another for the caching layer that extends the base.  I'm using separate classes to make them testable. 