### PR TITLE
[WR-1436] remove mobile auto-scroll

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/base-component.model.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/base-component.model.ts
@@ -17,11 +17,6 @@ export class BaseFilterComponent {
     if (this.ngbDropdown) {
       this.ngbDropdown.close();
     }
-
-    // Make sure dropdown is completely closed before scroll into view
-    setTimeout(() => {
-      this.filterService.scrollIntoView(dropdownMenuId);
-    }, 0);
   }
 }
 

--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/services/filter.service.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/services/filter.service.ts
@@ -1527,7 +1527,7 @@ export class FilterService extends BaseService {
       case 'postal': {
         const postals = value.split(',');
         for (let k = 0; k < postals.length; k++) {
-          // only set the top cityOrPosal filter if the postal code is in the
+          // only set the top cityOrPostal filter if the postal code is in the
           // first location position (i.e. if the array is currently empty)
           if (!mainFilters.locationFields.length) {
             if (!mainFilters.keywordFilters.cityOrPostal.length) {
@@ -1642,40 +1642,5 @@ export class FilterService extends BaseService {
       result = locationPath.substring(locationPath.indexOf(';'));
     }
     return result;
-  }
-
-  get requireScrollFix() {
-    try {
-      //const isOpera = !!(window as any).opera || navigator.userAgent.indexOf(' OPR/') >= 0;
-      //const isEdge = navigator.userAgent.indexOf("Edge") > -1;
-      //const isChrome = !!(window as any).chrome && !isOpera && !isEdge;
-      //const isFirefox = typeof (window as any).InstallTrigger !== 'undefined';
-      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-
-      const result = isSafari && (
-        navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i));
-      return result;
-
-    } catch (e) {
-      alert(e.message);
-    }
-  }
-
-  scrollIntoView(dropdownMenuId = '', elementId = 'searchScrollAnchor'): void {
-    // Note: This only impacts mobile, since #searchScrollAnchor is hidden using 
-    // class="d-md-none" (scrollIntoView doesn't work on a hidden element)
-
-    const htmlElement = document.getElementById(elementId);
-
-    if (htmlElement) {
-      if (this.requireScrollFix && dropdownMenuId) {
-        const dropdownMenu = document.getElementById(dropdownMenuId);
-        const y = htmlElement.offsetTop - dropdownMenu?.offsetHeight + 20;
-        window.scrollTo({ top: y, behavior: 'smooth' });
-      }
-      else {
-        htmlElement.scrollIntoView(); // If not scroll into view as usual.
-      }
-    }
   }
 }

--- a/src/WorkBC.Web/ClientApp/projects/jb-search/src/app/job-search/results/results.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-search/src/app/job-search/results/results.component.ts
@@ -88,7 +88,6 @@ export class ResultsComponent implements OnInit {
   mappedJobCount = 0;
   results: Job[];
   mainFilterModel: MainFilterModel;
-  justLoaded = false;
 
   // pagination control
   @ViewChild('pagination')
@@ -104,7 +103,7 @@ export class ResultsComponent implements OnInit {
   markers: google.maps.Marker[];
 
   //reference to the clusters on the map
-  markerCluster: MarkerClusterer; 
+  markerCluster: MarkerClusterer;
 
   //Show map on screen
   showMap = false;
@@ -194,14 +193,6 @@ export class ResultsComponent implements OnInit {
           this.mainFilterModel.pagination.currentPage = 1;
           this.filterService.setFilters();
         }
-
-        // scroll to the searchSrollAnchor
-        if (!this.justLoaded) {
-          this.filterService.scrollIntoView();
-        }
-
-        // don't scroll to the searchSrollAnchor the first time the page loads
-        this.justLoaded = false;
 
         //paging
         this.paginationElement.setResultCount(this.resultsCount);
@@ -362,7 +353,7 @@ export class ResultsComponent implements OnInit {
 
           //add "click" event to marker
           google.maps.event.addListener(marker, 'click', () => {
-            this.onMarkerClick(marker); 
+            this.onMarkerClick(marker);
           });
 
           return marker;
@@ -432,7 +423,7 @@ export class ResultsComponent implements OnInit {
                   There are ${jobIdMarkers.length} jobs at this location
                   <img src="${this.globalService.getApiBaseUrl()}assets/icons/arrow-right.svg" width="14px" height="14px">
                </div>
-               <div id="jobDetails" hidden class="p-1">`; 
+               <div id="jobDetails" hidden class="p-1">`;
           }
 
           for (let i = 0; i < result.length; i++) {


### PR DESCRIPTION
At present, when **mobile** users enter filter criteria and click search, the application automatically scrolls the user to the results section of the page.  This PR removes this functionality.