### PR TITLE
Use IClassTestFixture to set up Elastic index once

### DIFF
--- a/src/WorkBC.Shared/Utilities/ElasticHttpHelper.cs
+++ b/src/WorkBC.Shared/Utilities/ElasticHttpHelper.cs
@@ -151,7 +151,8 @@ namespace WorkBC.Shared.Utilities
                 }
                 else if (!result.IsSuccessStatusCode)
                 {
-                    throw new Exception($"Elasticsearch returned a {result.StatusCode} status code");
+                    throw new Exception($"Elasticsearch returned a {result.StatusCode} " +
+                                        $"status code: {url} JSON {json}");
                 }
 
                 return await result.Content.ReadAsStringAsync();

--- a/src/WorkBC.Tests/Helpers/SearchTestHelpers.cs
+++ b/src/WorkBC.Tests/Helpers/SearchTestHelpers.cs
@@ -45,7 +45,9 @@ namespace WorkBC.Tests.Helpers
         public async Task<List<Source>> GetJobsWithEmploymentGroup(bool isApprentice, bool isIndigenous, bool isMatureWorker, bool isNewcomer, bool isPeopleWithDisabilities, bool isStudents, bool isVeterans, bool isVisibleMinority, bool isYouth)
         {
             //Create an instance with the filters required
-            JobSearchQuery esq = new JobSearchQuery(_geocodingService, _configuration, GetFiltersForJobByEmployerGroup(isApprentice, isIndigenous, isMatureWorker, isNewcomer, isPeopleWithDisabilities, isStudents, isVeterans, isVisibleMinority, isYouth));
+            var filters = GetFiltersForJobByEmployerGroup(isApprentice, isIndigenous, isMatureWorker, isNewcomer,
+                isPeopleWithDisabilities, isStudents, isVeterans, isVisibleMinority, isYouth);
+            var esq = new JobSearchQuery(_geocodingService, _configuration, filters);
 
             //return results
             return await QueryElasticSearch(esq);

--- a/src/WorkBC.Tests/Tests/ElasticSearchTestFixture.cs
+++ b/src/WorkBC.Tests/Tests/ElasticSearchTestFixture.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,12 +16,13 @@ using WorkBC.Shared.Settings;
 using WorkBC.Tests.FakeServices;
 using WorkBC.Tests.Fixtures;
 using WorkBC.Tests.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 using Location = WorkBC.Data.Model.JobBoard.Location;
 
 namespace WorkBC.Tests.Tests
 {
-    public abstract class TestsBase : IDisposable
+    public class ElasticSearchTestFixture : IDisposable
     {
         protected readonly IConfiguration Configuration;
 
@@ -29,14 +30,15 @@ namespace WorkBC.Tests.Tests
         protected readonly ElasticSearchSetupHelpers ElasticService;
         protected readonly IGeocodingService GeocodingService;
 
-        protected TestsBase(ITestOutputHelper output)
+        // Constructor
+        public ElasticSearchTestFixture()
         {
             #region AppSettings
 
             IConfigurationBuilder builder = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true, true)
-                .AddUserSecrets<TestsBase>()
+                .AddUserSecrets<TestsHelper>()
                 .AddEnvironmentVariables();
 
             IConfiguration configuration = builder.Build();
@@ -93,27 +95,6 @@ namespace WorkBC.Tests.Tests
             ElasticService.DestroyUnitTestIndex();
         }
 
-        #region Helpers
 
-        protected async Task<List<Source>> QueryElasticSearch(JobSearchQuery esq)
-        {
-            //Get search results from Elastic search
-            ElasticSearchResponse results = await esq.GetSearchResults();
-
-            //Read results from Elastic
-            if (results != null)
-            {
-                if (results.Hits != null && results.Hits.HitsHits != null)
-                {
-                    //Return results to test
-                    return results.Hits.HitsHits.Select(hit => hit.Source).ToArray().ToList();
-                }
-            }
-
-            //If no results, return empty result set
-            return new List<Source>();
-        }
-
-        #endregion
     }
 }

--- a/src/WorkBC.Tests/Tests/GeocodingServiceTests.cs
+++ b/src/WorkBC.Tests/Tests/GeocodingServiceTests.cs
@@ -9,11 +9,10 @@ using WorkBC.Data.Model.JobBoard;
 using WorkBC.Shared.Services;
 using WorkBC.Tests.FakeServices;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace WorkBC.Tests.Tests
 {
-    public class GeocodingServiceTests : TestsBase
+    public class GeocodingServiceTests : IClassFixture<ElasticSearchTestFixture>
     {
         //Properties
         private readonly GeocodingCachingService _geocodingCachingService;
@@ -35,14 +34,15 @@ namespace WorkBC.Tests.Tests
         };
 
         // Constructor
-        public GeocodingServiceTests(ITestOutputHelper output) : base(output)
+        public GeocodingServiceTests()
         {
             // Get database connection string from appsettings.json
-            string connectionString = Configuration.GetConnectionString("DefaultConnection");
+            var configuration = TestsHelper.GetConfiguration();
+            var connectionString = configuration.GetConnectionString("DefaultConnection");
             _dbContext = new JobBoardContext(connectionString);
             
             //Services
-            _geocodingService = new FakeGeocodingService(Configuration);
+            _geocodingService = new FakeGeocodingService(configuration);
             var logger = new LoggerFactory().CreateLogger<IGeocodingService>();
             _geocodingCachingService = new GeocodingCachingService(_dbContext, _geocodingService, logger);
         }

--- a/src/WorkBC.Tests/Tests/TestsHelper.cs
+++ b/src/WorkBC.Tests/Tests/TestsHelper.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using WorkBC.Data.Model.JobBoard;
+using WorkBC.ElasticSearch.Indexing.Services;
+using WorkBC.ElasticSearch.Indexing.Settings;
+using WorkBC.ElasticSearch.Models.JobAttributes;
+using WorkBC.ElasticSearch.Models.Results;
+using WorkBC.ElasticSearch.Search.Queries;
+using WorkBC.Shared.Services;
+using WorkBC.Shared.Settings;
+using WorkBC.Tests.FakeServices;
+using WorkBC.Tests.Fixtures;
+using WorkBC.Tests.Helpers;
+using Xunit.Abstractions;
+using Location = WorkBC.Data.Model.JobBoard.Location;
+
+namespace WorkBC.Tests.Tests
+{
+    public abstract class TestsHelper
+    {
+
+        public static async Task<List<Source>> QueryElasticSearch(JobSearchQuery esq)
+        {
+            //Get search results from Elastic search
+            ElasticSearchResponse results = await esq.GetSearchResults();
+
+            //Read results from Elastic
+            if (results != null)
+            {
+                if (results.Hits != null && results.Hits.HitsHits != null)
+                {
+                    //Return results to test
+                    return results.Hits.HitsHits.Select(hit => hit.Source).ToArray().ToList();
+                }
+            }
+
+            //If no results, return empty result set
+            return new List<Source>();
+        }
+
+        public static IConfiguration GetConfiguration()
+        {
+            IConfigurationBuilder builder = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", true, true)
+                .AddUserSecrets<TestsHelper>()
+                .AddEnvironmentVariables();
+
+            IConfiguration configuration = builder.Build();
+
+            var indexSettings = new IndexSettings();
+            var connectionSettings = new ConnectionSettings();
+
+            configuration.GetSection("IndexSettings").Bind(indexSettings);
+            configuration.GetSection("ConnectionStrings").Bind(connectionSettings);
+
+            return configuration;
+        }
+        
+    }
+}


### PR DESCRIPTION
Instead of using a base class from which every test class extends, use an `ITestFixture`. 

An `ITestFixture` is instantiated only once per test run so it's preferable to using a base class for creating a the ElasticSearch index.  Previously, the ElasticSearch was created and destroyed on every test which not only slows our UnitTests but may be causing build problems.