### PR TITLE
[WR-1562] remove source maps from production

### DIFF
--- a/src/WorkBC.Web/ClientApp/angular.json
+++ b/src/WorkBC.Web/ClientApp/angular.json
@@ -69,7 +69,7 @@
             "vendorChunk": true,
             "extractLicenses": false,
             "buildOptimizer": false,
-            "sourceMap": true,
+            "sourceMap": false,
             "optimization": false,
             "namedChunks": true
           },
@@ -243,7 +243,7 @@
             "vendorChunk": true,
             "extractLicenses": false,
             "buildOptimizer": false,
-            "sourceMap": true,
+            "sourceMap": false,
             "optimization": false,
             "namedChunks": true
           },


### PR DESCRIPTION
Very simple change to remove source maps from the production build. 