### PR TITLE
[WBCAMS-220] gracefully handle BadHttpRequestException

### DIFF
--- a/src/WorkBC.Web/Helpers/BadHttpRequestExceptionFilter.cs
+++ b/src/WorkBC.Web/Helpers/BadHttpRequestExceptionFilter.cs
@@ -1,0 +1,29 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace WorkBC.Web.Helpers;
+
+public class BadHttpRequestExceptionFilter : IExceptionFilter
+{
+    
+    public void OnException(ExceptionContext context)
+    {
+        if (context.ExceptionHandled) return;
+        var exception = context.Exception;
+        if (exception is not BadHttpRequestException) return;
+        
+        var result = new ObjectResult(new
+        {
+            context.Exception.Message,
+            context.Exception.Source,
+            ExceptionType = context.Exception.GetType().FullName
+        })
+        {
+            StatusCode = (int?)HttpStatusCode.InternalServerError
+        };
+        context.Result = result;
+    }
+}

--- a/src/WorkBC.Web/Helpers/BadHttpRequestExceptionFilter.cs
+++ b/src/WorkBC.Web/Helpers/BadHttpRequestExceptionFilter.cs
@@ -1,25 +1,43 @@
-﻿using System.Net;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Serilog;
 
 namespace WorkBC.Web.Helpers;
 
 public class BadHttpRequestExceptionFilter : IExceptionFilter
 {
+    private readonly ILogger _logger;
+    
+    // Constructor
+    public BadHttpRequestExceptionFilter(ILogger logger)
+    {
+        _logger = logger;
+    }
     
     public void OnException(ExceptionContext context)
     {
         if (context.ExceptionHandled) return;
         var exception = context.Exception;
         if (exception is not BadHttpRequestException) return;
+
+        var fullErrorName = context.Exception.GetType().FullName;
+        var endpoint = context.HttpContext.Request.Path;
+        var method = context.HttpContext.Request.Method;
         
+        // unable to log the payload since it's not completely received, hence this exception
+        _logger.Error(fullErrorName + ": endpoint: " + endpoint + " method: " + method );
         var result = new ObjectResult(new
         {
             context.Exception.Message,
             context.Exception.Source,
-            ExceptionType = context.Exception.GetType().FullName
+            ExceptionType = fullErrorName
         })
         {
             StatusCode = (int?)HttpStatusCode.InternalServerError

--- a/src/WorkBC.Web/Startup.cs
+++ b/src/WorkBC.Web/Startup.cs
@@ -159,6 +159,10 @@ namespace WorkBC.Web
                 ServiceLifetime.Scoped));
 
             services.AddMvc(options => options.EnableEndpointRouting = false);
+            services.AddMvc(options =>
+            {
+                options.Filters.Add(typeof(BadHttpRequestExceptionFilter));
+            });
 
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
@@ -268,7 +272,7 @@ namespace WorkBC.Web
                     c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
                 });
             }
-
+            
             app.UseHttpsRedirection();
             app.UseStaticFiles(new StaticFileOptions
             {

--- a/src/WorkBC.Web/Startup.cs
+++ b/src/WorkBC.Web/Startup.cs
@@ -272,7 +272,7 @@ namespace WorkBC.Web
                     c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
                 });
             }
-            
+
             app.UseHttpsRedirection();
             app.UseStaticFiles(new StaticFileOptions
             {


### PR DESCRIPTION
Add a filter to gracefully handle a `BadHttpRequestException`

Using curl, we can trigger the exception like by telling the server expect a payload that's longer than what we actually send.  Like this:

`curl -X 'POST' 'http://192.168.10.197:9223/api/Search/JobSearch' -H 'Content-Type: application/json' -H 'Content-Length: 200' -d '{"Page":1"'`

Prior to this pull request, the server responds with an exception, like this:

> Microsoft.AspNetCore.Server.Kestrel.Core.BadHttpRequestException: Reading the request body timed out due to data arriving too slowly. See MinRequestBodyDataRate.
>    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1ContentLengthMessageBody.ReadAsyncInternal(CancellationToken cancellationToken)
>    at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
>    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpRequestStream.ReadAsyncInternal(Memory`1 destination, CancellationToken cancellationToken)
>    at Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken)
>    at Microsoft.AspNetCore.WebUtilities.StreamHelperExtensions.DrainAsync(Stream stream, ArrayPool`1 bytePool, Nullable`1 limit, CancellationToken cancellationToken)
>    at Microsoft.AspNetCore.Mvc.Formatters.NewtonsoftJsonInputFormatter.ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
>    at Microsoft.AspNetCore.Mvc.ModelBinding.Binders.BodyModelBinder.BindModelAsync(ModelBindingContext bindingContext)
>    at Microsoft.AspNetCore.Mvc.ModelBinding.ParameterBinder.BindModelAsync(ActionContext actionContext, IModelBinder modelBinder, IValueProvider valueProvider, ParameterDescriptor parameter, ModelMetadata metadata, Object value, Object container)
>    at Microsoft.AspNetCore.Mvc.Controllers.ControllerBinderDelegateProvider.<>c__DisplayClass0_0.<<CreateBinderDelegate>g__Bind|0>d.MoveNext()
> --- End of stack trace from previous location ---

After this change, the server responds like this:

> {
>   "message": "Reading the request body timed out due to data arriving too slowly. See MinRequestBodyDataRate.",
>   "source": "Microsoft.AspNetCore.Server.Kestrel.Core",
>   "exceptionType": "Microsoft.AspNetCore.Server.Kestrel.Core.BadHttpRequestException"
> }
