### PR TITLE
[WBCAMS-264] do not grey out expired jobs rev2

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
@@ -56,10 +56,11 @@ export class ItemComponent {
         const offSetHours = offSet / 60 - 1;
         const offSetMinutes = offSet % 60;
         const today = new Date();
-        // Get the time zone offset by adding/subtracting hours to "today", then set today to "0, 0, 0, 0" the start of the day for purposes of this calculation
+        // Get the time zone offset by adding/subtracting hours to "today", then set today time
+        // to end-of-day for purposes of this calculation
         today.setHours(today.getHours() + offSetHours);
         today.setMinutes(today.getMinutes() + offSetMinutes);
-        today.setHours(0, 0, 0, 0);
+        today.setHours(23, 59, 59, 0);
         // Expire date is always the local computer time (assumed to be the time the user is in)
         const expireDate = new Date(this.item.ExpireDate);
         result = expireDate < today;

--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
@@ -52,18 +52,12 @@ export class ItemComponent {
     if (this.item) {
       result = this.inSavedJobsView && !this.item.IsActive;
       if (!result && this.item.ExpireDate) {
-        const offSet = new Date().getTimezoneOffset();
-        const offSetHours = offSet / 60 - 1;
-        const offSetMinutes = offSet % 60;
         const today = new Date();
-        // Get the time zone offset by adding/subtracting hours to "today", then set today time
-        // to end-of-day for purposes of this calculation
-        today.setHours(today.getHours() + offSetHours);
-        today.setMinutes(today.getMinutes() + offSetMinutes);
-        today.setHours(23, 59, 59, 0);
-        // Expire date is always the local computer time (assumed to be the time the user is in)
+        today.setHours(0, 0, 0, 0);
+
         const expireDate = new Date(this.item.ExpireDate);
-        result = expireDate < today;
+        expireDate.setHours(23, 59, 59, 0);
+        result = expireDate.getTime() < today.getTime();
       }
     }
     return result;

--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/job.model.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/job.model.ts
@@ -274,7 +274,8 @@ export class Job extends RecommendedJob {
     return result;
   }
 
-  //ExpiresIn: number;
+  //ExpiresIn: returns an integer that represents the number
+  // of days between now and the job expiry date;
   get ExpiresIn(): number {
     const oneDay = 86400000;
     let result = -1;
@@ -282,7 +283,7 @@ export class Job extends RecommendedJob {
       const dateNow = new Date();
       dateNow.setHours(0, 0, 0, 0);
       const expireDate = new Date(this.ExpireDate);
-      expireDate.setHours(0, 0, 0, 0);
+      expireDate.setHours(23, 59, 59, 0);
       const diffDays = Math.round((expireDate.getTime() - dateNow.getTime()) / oneDay);
       result = diffDays;
     }


### PR DESCRIPTION
Second attempt to fix this issue.  This pull request now uses the same logic when calculating `IsExpired()` and `ExpiresIn()`.  There's a small number of lines now duplicated, but without unit tests, I'm hesitant to clean it up.