### PR TITLE
[WBCAMS-287] elastic job searches must have a salary

### DIFF
--- a/src/WorkBC.ElasticSearch.Models/Filters/JobSearchFilters.cs
+++ b/src/WorkBC.ElasticSearch.Models/Filters/JobSearchFilters.cs
@@ -137,7 +137,8 @@ namespace WorkBC.ElasticSearch.Models.Filters
         [DefaultValue(false)]
         public bool SearchSalaryUnknown { get; set; }
 
-        /// <example></example>
+        
+        [DefaultValue(1)]
         public string SalaryMin { get; set; }
 
         /// <example></example>

--- a/src/WorkBC.ElasticSearch.Models/Filters/JobSearchFilters.cs
+++ b/src/WorkBC.ElasticSearch.Models/Filters/JobSearchFilters.cs
@@ -133,12 +133,8 @@ namespace WorkBC.ElasticSearch.Models.Filters
 
         [DefaultValue(false)]
         public bool SalaryBracket6 { get; set; }
-
-        [DefaultValue(false)]
-        public bool SearchSalaryUnknown { get; set; }
-
         
-        [DefaultValue(1)]
+        /// <example></example>
         public string SalaryMin { get; set; }
 
         /// <example></example>

--- a/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
+++ b/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
@@ -175,11 +175,13 @@ namespace WorkBC.ElasticSearch.Search.Queries
             #endregion
 
             #region Salary search
+            
+            // to be in compliance with legislation, all jobs returned must have a posted salary
+            var jsonSalaryFilter = "{ \"range\": { \"Salary\": { \"gte\": 1 } } }";
 
-            if (_filters.SearchSalaryUnknown || (SalarySearchType != SalaryType.NONE && SalaryRanges.Count > 0))
+            if (SalarySearchType != SalaryType.NONE && SalaryRanges.Count > 0)
             {
-                var jsonSalaryFilter = "";
-
+                jsonSalaryFilter = "";
                 var k = 0;
                 foreach (KeyValuePair<string, string> salaryRange in SalaryRanges)
                 {
@@ -206,22 +208,11 @@ namespace WorkBC.ElasticSearch.Search.Queries
 
                     k++;
                 }
-
-                if (_filters.SearchSalaryUnknown)
-                {
-                    if (k > 0)
-                    {
-                        jsonSalaryFilter += ",";
-                    }
-
-                    // You can't search for null so we search in SalarySort.Descending instead.  
-                    // The indexer sets this field to -99999999 for jobs with no salary.
-                    jsonSalaryFilter += "{ \"range\": { \"SalarySort.Descending\": { \"lte\": -99999999 } } }";
-                }
-
-                filterGroups.Add(jsonSalaryFilter);
             }
+            
+            filterGroups.Add(jsonSalaryFilter);
 
+            // filter for benefits
             if (SearchSalaryConditions != null && SearchSalaryConditions.Count > 0)
             {
                 var jsonBenefits = string.Empty;

--- a/src/WorkBC.Shared/Extensions/JobSearchFiltersExtensions.cs
+++ b/src/WorkBC.Shared/Extensions/JobSearchFiltersExtensions.cs
@@ -347,11 +347,6 @@ namespace WorkBC.Shared.Extensions
                 salaryBracketList.Add(6);
             }
 
-            if (filters.SearchSalaryUnknown)
-            {
-                salaryBracketList.Add(7);
-            }
-
             if (salaryBracketList.Any())
             {
                 salaryParams += $"salaryrange={string.Join(",", salaryBracketList)};";

--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/salary/salary.component.html
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/salary/salary.component.html
@@ -92,29 +92,6 @@
           <input type="text" class="form-control" aria-label="Custom salary range maximum amount" placeholder="unlimited" [(ngModel)]="vm.maxAmount"
                  (keyup)="onMaxAmountChange($event.target.value)" [disabled]="!vm.amountRange6" />
         </div>
-        <div class="salary-ranges above-tooltip">
-          <div class="check-group">
-            <input type="checkbox" [(ngModel)]="vm.searchSalaryUnknown" name="searchSalaryUnknown"
-                   id="searchSalaryUnknown" />
-            <div class="checkbox-icons">
-              <lib-svg-icon icon="checkbox" width="16px" height="16px" class="checkbox"></lib-svg-icon>
-              <lib-svg-icon icon="checkbox-checked" width="16px" height="16px" class="checkbox"></lib-svg-icon>
-            </div>
-            <label class="form-check-label" for="searchSalaryUnknown">Unknown salaries</label>
-            <button type="button" class="tooltip-icon" placement="bottom" (click)="salaryTip.toggle()"
-                    [autoClose]="'outside'" [ngbPopover]="SalaryUnknownPopContent" [triggers]="getPopoverTriggers()" #salaryTip="ngbPopover">
-              <lib-svg-icon icon="info-blue" width="20px" height="20px" class="info"></lib-svg-icon>
-              <span class="sr-only">
-                {{unknownSalaries}}
-              </span>
-              <ng-template #SalaryUnknownPopContent>
-                {{unknownSalaries}}
-                <!-- empty link fixes mobile issue requiring double-tab -->
-                <a href="#" tabindex="-1" aria-hidden="true"></a>
-              </ng-template>
-            </button>
-          </div>
-        </div>
       </div>
       <div class="col-lg-7">
         <div class="salary-filter-types">


### PR DESCRIPTION
This pull request changes the default Elastic Search query so that jobs must have a salary and removes from the GUI the ability to search for jobs without a salary.  I'm taking a light touch to the changes to ensure this change passes QA as quickly as possible as I expect the client will want to push this into PROD as quickly as possible.