### PR TITLE
[WBCAMS-279] and [WBCAMS-278] fix pagination issues

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/pagination/pagination.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/pagination/pagination.component.ts
@@ -114,7 +114,7 @@ export class PaginationComponent implements OnInit {
       }
     }
     //check for the last two pages
-    else if (this.vm.currentPage + _pagesThreshold >= this.pageCount) {
+    else if (this.vm.currentPage + _pagesThreshold <= this.pageCount) {
       this.pages = new Array<number>();
       for (let i = this.pageCount - _pagesVisible; i < this.pageCount; i++) {
         if (i + 1 > 0) {

--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/search-criteries/search-criteries.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/search-criteries/search-criteries.component.ts
@@ -42,6 +42,7 @@ export class SearchCriteriesComponent {
 
   clearAll(): void {
     this.cleared.emit();
+    this.filterService.removeFilter("page")
     this.filterService.setBookmarkableUrl(null, this.inJobAlert, this.router.url);
   }
 }


### PR DESCRIPTION
Fix two pagination issues:

- when returning from job detail page, display the correct page in the footer
- when filters are cleared, return to page 1