### PR TITLE
[WBCAMS-287] update XML used for unit tests

### DIFF
--- a/src/WorkBC.Tests/Fixtures/WantedXmlJobs/4049109571.xml
+++ b/src/WorkBC.Tests/Fixtures/WantedXmlJobs/4049109571.xml
@@ -20,7 +20,7 @@
     </location>
   </locations>
   <salaries>
-    <salary id="2" type="Modeled" value="62000" />
+    <salary id="2" type="Posted" value="62000" />
   </salaries>
   <jobtypes>
     <jobtype id="4" label="Full-Time" /><jobtype id="1" label="Permanent" />

--- a/src/WorkBC.Tests/Fixtures/WantedXmlJobs/4049109576.xml
+++ b/src/WorkBC.Tests/Fixtures/WantedXmlJobs/4049109576.xml
@@ -19,7 +19,7 @@
     </location>
   </locations>
   <salaries>
-    <salary id="2" type="Modeled" value="42000" />
+    <salary id="2" type="Posted" value="42000" />
   </salaries>
   <jobtypes>
     <jobtype id="4" label="Full-Time" /><jobtype id="1" label="Permanent" />


### PR DESCRIPTION
Modify sample job XML files used for unit testing.  Without these changes, the unit tests will complain that the job expected cannot be found.