### PR TITLE
[WBCAMS-278] fix job board pagination rev2

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/pagination/pagination.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/pagination/pagination.component.ts
@@ -114,7 +114,7 @@ export class PaginationComponent implements OnInit {
       }
     }
     //check for the last two pages
-    else if (this.vm.currentPage + _pagesThreshold <= this.pageCount) {
+    else if (Number(this.vm.currentPage) + _pagesThreshold >= this.pageCount) {
       this.pages = new Array<number>();
       for (let i = this.pageCount - _pagesVisible; i < this.pageCount; i++) {
         if (i + 1 > 0) {

--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/search-criteries/search-criteries.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/search-criteries/search-criteries.component.ts
@@ -42,7 +42,7 @@ export class SearchCriteriesComponent {
 
   clearAll(): void {
     this.cleared.emit();
-    this.filterService.removeFilter("page")
+    this.removeFilter("page")
     this.filterService.setBookmarkableUrl(null, this.inJobAlert, this.router.url);
   }
 }


### PR DESCRIPTION
My initial assumption was incorrect.  The cause of the pagination problem is that  `currentPage` is a number when navigating using paginator, but is a string when passed in from the URL.  