### PR TITLE
[WBCAMS-146] optimize datafirstimported query

### DIFF
--- a/src/WorkBC.Admin/Services/SelectListService.cs
+++ b/src/WorkBC.Admin/Services/SelectListService.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using WorkBC.Data;
 using WorkBC.Data.Enums;
-using WorkBC.Data.Model.JobBoard;
 
 namespace WorkBC.Admin.Services
 {
@@ -180,9 +179,11 @@ namespace WorkBC.Admin.Services
         {
             get
             {
-                List<int> years = _jobBoardContext.Jobs.Select(j => j.DateFirstImported.Year).Distinct().OrderBy(y => y).ToList();
-
-                // years = years.Prepend(years.Min() - 1).ToList();
+                List<int> years = _jobBoardContext.Jobs
+                    .GroupBy(j => j.DateFirstImported.Year)
+                    .Select(g => g.Key)
+                    .OrderBy(y => y)
+                    .ToList();
 
                 if (DateTime.Now.Month >= 4)
                 {


### PR DESCRIPTION
The current query LINQ query creates inefficient SQL that uses `DISTINCT` instead of  `GROUP BY`.  I've tested this locally, but only with a very small Jobs table.  Without more time, I couldn't import the text file the client provided because of the hobbled text file importer MS-SQL provides.  To test this properly, we would need:
- a copy of the database,
- permission to port forward my local machine to the AWS database,
- an import script that parses, transforms and imports the table data correctly
