### PR TITLE
[WBCAMS-23] do not grey-out saved jobs

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.html
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.html
@@ -1,5 +1,5 @@
 <div class="job-item print-no-break">
-  <div class="row" [ngClass]="{'expired': isExpired }">
+  <div class="row">
     <div class="col-12 col-lg-8 job-info">
       <div class="title">
         <a *ngIf="item.IsFederalJob" [attr.href]="isExpired ? null : jobDetailsUrl">
@@ -40,27 +40,27 @@
     <div class="col-12 col-lg-2 cta-contain">
       <div class="expiry" *ngIf="item.IsFederalJob">
         <div class="expires-in">
-          <strong>{{isExpired ? "Expired" : "Expires in " + item.ExpiresIn + " days"}}</strong>
+          <strong>{{"Expires in " + item.ExpiresIn + " days"}}</strong>
         </div>
         <div class="expiry-date text-nowrap">
-          Expires: 
+          Expires:
           <span aria-hidden="true">{{item.ExpireDate | date:'yyyy-MM-dd'}}</span>
           <span class="sr-only">{{item.ExpireDate | date:'MMMM d, yyyy'}}</span>
         </div>
         <div class="post-date text-nowrap">
-          Posted: 
+          Posted:
           <span aria-hidden="true">{{item.DatePosted | date:'yyyy-MM-dd'}}</span>
           <span class="sr-only">{{item.DatePosted | date:'MMMM d, yyyy'}}</span>
         </div>
         <div class="post-date text-nowrap">
-          Last Updated: 
+          Last Updated:
           <span aria-hidden="true">{{item.LastUpdated | date:'yyyy-MM-dd'}}</span>
           <span class="sr-only">{{item.LastUpdated | date:'MMMM d, yyyy'}}</span>
         </div>
       </div>
       <!-- if there is no expiry date, render posted date on it's own -->
       <div class="post-date" *ngIf="!item.IsFederalJob">
-        Posted: 
+        Posted:
         <span aria-hidden="true">{{item.DatePosted | date:'yyyy-MM-dd'}}</span>
         <span class="sr-only">{{item.DatePosted | date:'MMMM d, yyyy'}}</span>
       </div>


### PR DESCRIPTION
This pull request stops saved jobs from being greyed-out when expired by removing the logic that adds an "expired" css class to the job item.