### PR TITLE
[WBCAMS-23] correct isExpired() algorithm

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
@@ -54,7 +54,7 @@ export class ItemComponent {
       if (!result && this.item.ExpireDate) {
         const today = new Date(); // user's local time zone
         const expireDate = new Date(this.item.ExpireDate);
-        result = expireDate.getDate() < today.getDate();
+        result = expireDate < today;
       }
     }
     return result;


### PR DESCRIPTION
Fix date comparison in the `isExpired()` method.  