### PR TITLE
[WBCAMS-23] set expiry datetime to end of day

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/item/item.component.ts
@@ -53,7 +53,8 @@ export class ItemComponent {
       result = this.inSavedJobsView && !this.item.IsActive;
       if (!result && this.item.ExpireDate) {
         const today = new Date(); // user's local time zone
-        const expireDate = new Date(this.item.ExpireDate);
+        let expireDate = new Date(this.item.ExpireDate);
+        expireDate.setHours(23, 59, 59, 0);
         result = expireDate < today;
       }
     }


### PR DESCRIPTION
`ExpireDate`'s time component needs to be replaced with an end-of-day time in order for all jobs to expire at midnight as requested by the client.