### PR TITLE
[WBCAMS-297] fix fed, prov and muni job alert filters

### DIFF
--- a/src/WorkBC.Shared/Extensions/JobSearchFiltersExtensions.cs
+++ b/src/WorkBC.Shared/Extensions/JobSearchFiltersExtensions.cs
@@ -547,6 +547,24 @@ namespace WorkBC.Shared.Extensions
             {
                 moreParams += "jobsource=2;";
             }
+            
+            // Job source =  Federal Jobs (other job boards)
+            if (filters.SearchJobSource == "3")
+            {
+                moreParams += "jobsource=3;";
+            }
+            
+            // Job source =  Municipal Jobs (other job boards)
+            if (filters.SearchJobSource == "4")
+            {
+                moreParams += "jobsource=4;";
+            }
+            
+            // Job source =  Provincial Jobs (other job boards)
+            if (filters.SearchJobSource == "5")
+            {
+                moreParams += "jobsource=5;";
+            }
 
             return moreParams;
         }


### PR DESCRIPTION
Extending `BookmarkableUrl()` to include the new filters.  

Below is a screenshot of the job alert page in the current DEV environment.  Note that "Your search criteria" is blank

![Screenshot (77)](https://github.com/bcgov/workbc-jb/assets/25233684/41aff1dd-7eb0-43f8-9a46-18f40e83d362)

After implementing this PR: 

![Screenshot (22)](https://github.com/bcgov/workbc-jb/assets/25233684/57ce8230-dd4f-45bc-a4ec-d0bb5e82230c)

Note: the presentation between these two screenshots is slightly different because the first screenshot is taken from dev.workbc.ca (drupal) while the second screenshot is taken directly from the job board. 