### PR TITLE
[WBCAMS-293] update queen charlotte city name

### DIFF
--- a/src/WorkBC.Data/Migrations/20231222224412_UpdateQueenCharlotteCityName.Designer.cs
+++ b/src/WorkBC.Data/Migrations/20231222224412_UpdateQueenCharlotteCityName.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WorkBC.Data;
 
@@ -11,9 +12,10 @@ using WorkBC.Data;
 namespace WorkBC.Data.Migrations
 {
     [DbContext(typeof(JobBoardContext))]
-    partial class JobBoardContextModelSnapshot : ModelSnapshot
+    [Migration("20231222224412_UpdateQueenCharlotteCityName")]
+    partial class UpdateQueenCharlotteCityName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WorkBC.Data/Migrations/20231222224412_UpdateQueenCharlotteCityName.cs
+++ b/src/WorkBC.Data/Migrations/20231222224412_UpdateQueenCharlotteCityName.cs
@@ -8,34 +8,34 @@ namespace WorkBC.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("UPDATE Locations" +
-                                 "SET City = 'Daajing Giids ( Queen Charlotte City )', " +
-                                 "Label = 'Daajing Giids ( Queen Charlotte City )'" +
+            migrationBuilder.Sql("UPDATE Locations " +
+                                 "SET [City] = 'Daajing Giids ( Queen Charlotte City )', " +
+                                 "[Label] = 'Daajing Giids ( Queen Charlotte City )'" +
                                  "WHERE LocationId = '1594'");
 
-            migrationBuilder.Sql("UPDATE ImportedJobsFederal" +
-                                 "SET ReIndexNeeded = 1" +
-                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+            migrationBuilder.Sql("UPDATE ImportedJobsFederal " +
+                                 "SET [ReIndexNeeded] = 1" +
+                                 "WHERE JobId IN (SELECT [JobId] FROM Jobs where City = 'Queen Charlotte City')");
             
-            migrationBuilder.Sql("UPDATE ImportedJobsWanted" +
-                                 "SET ReIndexNeeded = 1" +
-                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+            migrationBuilder.Sql("UPDATE ImportedJobsWanted " +
+                                 "SET [ReIndexNeeded] = 1" +
+                                 "WHERE JobId IN (SELECT [JobId] FROM Jobs where City = 'Queen Charlotte City')");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("UPDATE Locations" +
-                                 "SET City = 'Queen Charlotte City', " +
-                                 "Label = 'Queen Charlotte City'" +
+            migrationBuilder.Sql("UPDATE Locations " +
+                                 "SET [City] = 'Queen Charlotte City', " +
+                                 "[Label] = 'Queen Charlotte City'" +
                                  "WHERE LocationId = '1594'");
             
-            migrationBuilder.Sql("UPDATE ImportedJobsFederal" +
-                                 "SET ReIndexNeeded = 0" +
-                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+            migrationBuilder.Sql("UPDATE ImportedJobsFederal " +
+                                 "SET [ReIndexNeeded] = 0" +
+                                 "WHERE JobId IN (SELECT [JobId] FROM Jobs where City = 'Queen Charlotte City')");
             
-            migrationBuilder.Sql("UPDATE ImportedJobsWanted" +
-                                 "SET ReIndexNeeded = 0" +
-                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+            migrationBuilder.Sql("UPDATE ImportedJobsWanted " +
+                                 "SET [ReIndexNeeded] = 0" +
+                                 "WHERE JobId IN (SELECT [JobId] FROM Jobs where City = 'Queen Charlotte City')");
             
         }
     }

--- a/src/WorkBC.Data/Migrations/20231222224412_UpdateQueenCharlotteCityName.cs
+++ b/src/WorkBC.Data/Migrations/20231222224412_UpdateQueenCharlotteCityName.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WorkBC.Data.Migrations
+{
+    public partial class UpdateQueenCharlotteCityName : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE Locations" +
+                                 "SET City = 'Daajing Giids ( Queen Charlotte City )', " +
+                                 "Label = 'Daajing Giids ( Queen Charlotte City )'" +
+                                 "WHERE LocationId = '1594'");
+
+            migrationBuilder.Sql("UPDATE ImportedJobsFederal" +
+                                 "SET ReIndexNeeded = 1" +
+                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+            
+            migrationBuilder.Sql("UPDATE ImportedJobsWanted" +
+                                 "SET ReIndexNeeded = 1" +
+                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE Locations" +
+                                 "SET City = 'Queen Charlotte City', " +
+                                 "Label = 'Queen Charlotte City'" +
+                                 "WHERE LocationId = '1594'");
+            
+            migrationBuilder.Sql("UPDATE ImportedJobsFederal" +
+                                 "SET ReIndexNeeded = 0" +
+                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+            
+            migrationBuilder.Sql("UPDATE ImportedJobsWanted" +
+                                 "SET ReIndexNeeded = 0" +
+                                 "WHERE JobId IN (SELECT JobId FROM Jobs where City = 'Queen Charlotte City')");
+            
+        }
+    }
+}

--- a/src/WorkBC.Data/README.md
+++ b/src/WorkBC.Data/README.md
@@ -3,7 +3,11 @@
 
 - In your development environment, install the migration tools globally using: 
   `dotnet tool install --global dotnet-ef --version 6.*`
-- Change directory to: `.\src\WorkBC.Web`
+- Change directory to: `.\src`
 - List the possible database contexts (required below): `dotnet-ef dbcontext list`
-- Create a new migration using: `dotnet ef migrations add <SomeMigrationName> --context JobBoardContext --project ..\WorkBC.Data`
+- Create a new migration using: `dotnet ef migrations add <SomeMigrationName> --project WorkBC.Data --startup-project WorkBC.Web --context JobBoardContext`
+
+### To test the migration locally
+- Change directory to: `.\src`
+- Run the migration using: `dotnet ef database update --project WorkBC.Data --startup-project WorkBC.Web --context JobBoardContext`
 

--- a/src/WorkBC.Data/README.md
+++ b/src/WorkBC.Data/README.md
@@ -1,0 +1,9 @@
+﻿
+### To create a migration
+
+- In your development environment, install the migration tools globally using: 
+  `dotnet tool install --global dotnet-ef --version 6.*`
+- Change directory to: `.\src\WorkBC.Web`
+- List the possible database contexts (required below): `dotnet-ef dbcontext list`
+- Create a new migration using: `dotnet ef migrations add <SomeMigrationName> --context JobBoardContext --project ..\WorkBC.Data`
+

--- a/src/WorkBC.ElasticSearch.Indexing/XmlParsingHelpers/XmlManualOverRides.cs
+++ b/src/WorkBC.ElasticSearch.Indexing/XmlParsingHelpers/XmlManualOverRides.cs
@@ -12,7 +12,8 @@ namespace WorkBC.ElasticSearch.Indexing.ParsingHelpers
         public static Dictionary<string, string> AlternateCityNames = new Dictionary<string, string>
         {
             {"one hundred mile house", "100 Mile House"},
-            {"queen charlotte", "Queen Charlotte City"},
+            {"queen charlotte", "Daajing Giids ( Queen Charlotte City )"},
+            {"queen charlotte city", "Daajing Giids ( Queen Charlotte City )"},
             {"cowichan valley a", "Lake Cowichan"},
             {"cowichan", "Lake Cowichan"},
             {"denny island", "Bella Bella"},


### PR DESCRIPTION
This pull request contains a migration script that:

- modifies the name of "Queen Charlotte City" to "Daajing Giids ( Queen Charlotte City )"
- rewrites the city name of newly imported Jobs to use the new name
- triggers existing jobs located in Queen Charlotte City (if any) to be renamed on the next Job update

To test, I've run the migration script locally and verified that the name is changed as expected and that any existing jobs are triggered to be updated, but since there aren't any current jobs located in Queen Charlotte City I haven't been able to verify that the update works correctly.

