### PR TITLE
[WBCAMS-310] display expireDate consistently

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/job.model.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/job.model.ts
@@ -170,7 +170,7 @@ export class Job extends RecommendedJob {
     if (savedJob) {
       this.City = savedJob.city;
       this.DatePosted = savedJob.datePosted.toString();
-      this.ExpireDate = savedJob.expireDate.toString();
+      this.ExpireDate = savedJob.expireDate.toString() + "-08:00"
       this.EmployerName = savedJob.employerName;
       this.JobId = savedJob.jobId.toString();
       this.SalarySummary = savedJob.salarySummary;

--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/job.model.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/models/job.model.ts
@@ -170,7 +170,7 @@ export class Job extends RecommendedJob {
     if (savedJob) {
       this.City = savedJob.city;
       this.DatePosted = savedJob.datePosted.toString();
-      this.ExpireDate = savedJob.expireDate.toString() + "-08:00"
+      this.ExpireDate = savedJob.expireDate.toString() + "-08:00";
       this.EmployerName = savedJob.employerName;
       this.JobId = savedJob.jobId.toString();
       this.SalarySummary = savedJob.salarySummary;


### PR DESCRIPTION
Screenshot below shows the expiry date as displayed on the Save Jobs page (left) and the Job Board (right).  The Expiry Date on both pages now display using the same timezone.  Note: the ugly date format shown is NOT what will users will see -- the format is used to illustrate the timezone for the purposes of this PR.

![Screenshot (83)](https://github.com/bcgov/workbc-jb/assets/25233684/3a9c0261-1d2a-448e-9e4f-b5717d7035ee)

Because the backend components use `Datetime.Now` instead of `Datetime.UtcNow` the time returned will vary with the environment.  This fix assumes that the server's time is in UTC.