### PR TITLE
WBCAMS-377-fix-federal-jobs-filter

### DIFF
--- a/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
+++ b/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
@@ -728,7 +728,7 @@ namespace WorkBC.ElasticSearch.Search.Queries
                     case "3":
                         // federal government
                         //These are an option on the Federal Job Bank and should be available through the federal XML feed.
-                        jsonJobSource = "{ \"term\": { \"EmployerTypeId\": 2 } }";
+                        jsonJobSource = "{ \"match_phrase_prefix\": { \"ExternalSource.Source.Url\": \"https://emploisfp-psjobs.cfp-psc.gc.ca\" } }";
                         break;
                     case "4":
                         // municipal government


### PR DESCRIPTION
Create ElasticSearch query string to search for federal government jobs using the source URL.

![Screenshot (33)](https://github.com/bcgov/workbc-jb/assets/25233684/2ad74ec7-83cd-4cb0-8fce-47e9d3bddbf6)
