### PR TITLE
[WBCAMS-377] fix federal jobs filter with nested attribute

### DIFF
--- a/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
+++ b/src/WorkBC.ElasticSearch.Search/Queries/JobSearchQuery.cs
@@ -728,7 +728,7 @@ namespace WorkBC.ElasticSearch.Search.Queries
                     case "3":
                         // federal government
                         //These are an option on the Federal Job Bank and should be available through the federal XML feed.
-                        jsonJobSource = "{ \"match_phrase_prefix\": { \"ExternalSource.Source.Url\": \"https://emploisfp-psjobs.cfp-psc.gc.ca\" } }";
+                        jsonJobSource = "{\"nested\": {\"path\": \"ExternalSource\",\"query\": {\"bool\": {\"should\": [{\"match_phrase\": {\"ExternalSource.Source.Url\":  \"https://emploisfp-psjobs.cfp-psc.gc.ca\"}}]}}}}";
                         break;
                     case "4":
                         // municipal government

--- a/src/WorkBC.Tests/Fixtures/WantedXmlJobs/6111648176.xml
+++ b/src/WorkBC.Tests/Fixtures/WantedXmlJobs/6111648176.xml
@@ -1,0 +1,30 @@
+﻿<job id="6111648176" hash="3563288114" refnumber="DOE24J-136996-000124" isstaffing="false" isanonymous="false" isthirdparty="false" isinappropriate="false" isbulk="false" isaggregator="false" isfree="false" isclassifiedoccupation="true" isclassifiedindustry="false" iscurrent="true" gartnerid="6111648176">
+    <dates firstseen="2024-02-23" posted="2024-02-23" refreshed="2024-02-23" />
+    <title value="Junior Engineer" titleid="31265" cleantitleid="37852612" semicleantitleid="40" />
+    <description value="Share this page - Email - Facebook - LinkedIn® - Twitter No endorsement of any products or services is expressed or implied. Share this page Junior Engineer Reference number: DOE24J-136996-000124 Selection process number: 23-DOE-ONT-EA-606814..." />
+    <occupation />
+    <industry code="0" label="Unspecified" />
+    <function id="6" label="Engineering / QA" />
+    <employer id="25227299" name="ENVIRONMENT AND CLIMATE CHANGE CANADA" superaliasid="25227299" superalias="ENVIRONMENT AND CLIMATE CHANGE CANADA" />
+    <education id="5" label="Bachelor's degree" />
+    <locations>
+        <location>
+            <city code="5915015" label="Richmond" />
+            <state code="BC" label="BC" />
+            <county code="5915" label="Greater Vancouver" />
+            <msa code="59933" label="Vancouver" />
+            <position latitude="49.1682014465332" longitude="-123.16699981689453" />
+        </location>
+    </locations>
+    <salaries>
+        <salary id="1" type="Posted" value="82795" />
+    </salaries>
+    <jobtypes>
+        <jobtype id="4" label="Full-Time" />
+        <jobtype id="1" label="Permanent" />
+    </jobtypes>
+    <tags />
+    <sources>
+        <source id="1572" jobid="6111648176" tags="" type="Corporate" name="ENVIRONMENT AND CLIMATE CHANGE CANADA" url="https://emploisfp-psjobs.cfp-psc.gc.ca/psrs-srfp/applicant/page1800?poster=2126701" validlink="true" />
+    </sources>
+</job>

--- a/src/WorkBC.Tests/WorkBC.Tests.csproj
+++ b/src/WorkBC.Tests/WorkBC.Tests.csproj
@@ -31,7 +31,6 @@
 
   <ItemGroup>
     <Folder Include="Fixtures\FederalXmlJobs\" />
-    <Folder Include="Fixtures\WantedXmlJobs\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -78,6 +77,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Fixtures\WantedXmlJobs\4049816178.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\WantedXmlJobs\6111648176.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
To fix the federal jobs filter requires an ElasticSearch query that uses a `nested` query.  The previous pull request relied on a mappings of the `jobs_en` index that were different from what are used in DEV (and presumably TEST and PROD).

I've added an additional XML to the test suite so the federal jobs query passes.