### PR TITLE
[WBCAMS-146] reduce queries on admin controller

### DIFF
--- a/src/WorkBC.Admin/Areas/Jobs/Controllers/JobSearchController.cs
+++ b/src/WorkBC.Admin/Areas/Jobs/Controllers/JobSearchController.cs
@@ -41,10 +41,7 @@ namespace WorkBC.Admin.Areas.Jobs.Controllers
         {
             // action inside a standard controller
             (IList<JobSearchViewModel> tempResult,
-                int filteredResultsCount,
-                int totalResultsCount,
-                int totalExternalCount,
-                int totalFederalCount) = await _service.Search(model);
+                int filteredResultsCount) = await _service.Search(model);
 
             var result = new List<JobSearchViewModel>(tempResult.Count);
 
@@ -57,11 +54,8 @@ namespace WorkBC.Admin.Areas.Jobs.Controllers
             {
                 // this is what datatables wants sending back
                 draw = model.Draw,
-                recordsTotal = totalResultsCount,
                 recordsFiltered = filteredResultsCount,
-                data = result,
-                totalExternal = totalExternalCount,
-                totalFederal = totalFederalCount
+                data = result
             });
         }
     }

--- a/src/WorkBC.Admin/Areas/Jobs/Services/JobService.cs
+++ b/src/WorkBC.Admin/Areas/Jobs/Services/JobService.cs
@@ -23,7 +23,7 @@ namespace WorkBC.Admin.Areas.Jobs.Services
 {
     public interface IJobService
     {
-        Task<(IList<JobSearchViewModel> result, int filteredResultsCount, int totalResultsCount, int totalExternalCount, int totalFederalCount)> Search(DataTablesModel model);
+        Task<(IList<JobSearchViewModel> result, int filteredResultsCount)> Search(DataTablesModel model);
 
         Task DeleteJob(long jobId, int currentAdminUserId);
     }
@@ -41,10 +41,7 @@ namespace WorkBC.Admin.Areas.Jobs.Services
 
 
         public async Task<(IList<JobSearchViewModel> result, 
-            int filteredResultsCount, 
-            int totalResultsCount, 
-            int totalExternalCount, 
-            int totalFederalCount)> Search(DataTablesModel model)
+            int filteredResultsCount)> Search(DataTablesModel model)
         {
             string searchBy = model.Search.Value;
             int take = model.Length;
@@ -68,10 +65,7 @@ namespace WorkBC.Admin.Areas.Jobs.Services
 
             // search the database taking into consideration table sorting and paging
             (List<JobSearchViewModel> result, 
-                    int filteredResultsCount,
-                    int totalResultsCount, 
-                    int totalExternalCount, 
-                    int totalFederalCount) = await GetDataFromDatabase(searchBy, take, skip, sortBy, sortDir, filter);
+                    int filteredResultsCount) = await GetDataFromDatabase(searchBy, take, skip, sortBy, sortDir, filter);
 
             if (result == null)
             {
@@ -79,7 +73,7 @@ namespace WorkBC.Admin.Areas.Jobs.Services
                 result = new List<JobSearchViewModel>();
             }
 
-            return (result, filteredResultsCount, totalResultsCount, totalExternalCount, totalFederalCount);
+            return (result, filteredResultsCount);
         }
 
         public async Task DeleteJob(long jobId, int currentAdminUserId)
@@ -208,10 +202,7 @@ namespace WorkBC.Admin.Areas.Jobs.Services
         }
 
         private async Task<(List<JobSearchViewModel> result,
-                int filteredResultsCount,
-                int totalResultsCount,
-                int totalExternalCount,
-                int totalFederalCount)>
+                int filteredResultsCount)>
             GetDataFromDatabase(string searchBy, int take, int skip, string sortBy, bool sortDir, string filter)
         {
             if (string.IsNullOrEmpty(sortBy))
@@ -250,16 +241,11 @@ namespace WorkBC.Admin.Areas.Jobs.Services
                     OriginalSource = m.OriginalSource
                 })
                 .ToListAsync();
-
-            // now just get the count of items (without the skip and take) - eg how many could be returned with filtering
-            int totalResultsCount = 0; // await queryable.CountAsync();
-            int totalFederalCount = 0; // await queryableNoFilter.CountAsync(q => q.JobSource.Name == "Federal");
-            int totalExternalCount = 0; // await queryableNoFilter.CountAsync(q => q.JobSource.Name == "Wanted");
-
+            
             //total results found by applying the filter
             int filteredResultsCount = await queryable.CountAsync();
 
-            return (result, filteredResultsCount, totalResultsCount, totalExternalCount, totalFederalCount);
+            return (result, filteredResultsCount);
         }
 
         private IQueryable<Job> FilterJobs(string searchBy, string filter)

--- a/src/WorkBC.Admin/Areas/Jobs/Services/JobService.cs
+++ b/src/WorkBC.Admin/Areas/Jobs/Services/JobService.cs
@@ -252,9 +252,9 @@ namespace WorkBC.Admin.Areas.Jobs.Services
                 .ToListAsync();
 
             // now just get the count of items (without the skip and take) - eg how many could be returned with filtering
-            int totalResultsCount = await queryable.CountAsync();
-            int totalFederalCount = await queryableNoFilter.CountAsync(q => q.JobSource.Name == "Federal");
-            int totalExternalCount = await queryableNoFilter.CountAsync(q => q.JobSource.Name == "Wanted");
+            int totalResultsCount = 0; // await queryable.CountAsync();
+            int totalFederalCount = 0; // await queryableNoFilter.CountAsync(q => q.JobSource.Name == "Federal");
+            int totalExternalCount = 0; // await queryableNoFilter.CountAsync(q => q.JobSource.Name == "Wanted");
 
             //total results found by applying the filter
             int filteredResultsCount = await queryable.CountAsync();

--- a/src/WorkBC.Admin/Areas/Jobs/Views/JobSearch/JobSearch.cshtml
+++ b/src/WorkBC.Admin/Areas/Jobs/Views/JobSearch/JobSearch.cshtml
@@ -21,15 +21,12 @@
     <div class="row row-search-filters">
         <button type="button" class="btn btn-search-filter btn-secondary btn-all active">
             <span>All</span>
-            <span class="number" id="spAll"></span>
         </button>
         <button type="button" class="btn btn-search-filter btn-federal btn-secondary">
             <span>Federal XML Feed</span>
-            <span class="number" id="spFederal"></span>
         </button>
         <button type="button" class="btn btn-search-filter btn-external btn-secondary">
             <span>External Job Posting API</span>
-            <span class="number" id="spExternal"></span>
         </button>
         <button type="button" id="btn-reset" class="btn btn-inline">
             <span>Reset search</span>

--- a/src/WorkBC.Admin/wwwroot/js/jobs.js
+++ b/src/WorkBC.Admin/wwwroot/js/jobs.js
@@ -178,13 +178,6 @@ $(document).ready(function () {
             { className: "urls", "targets": [8] },
             { className: "actions", "targets": [9] }
         ]
-    }).on('xhr.dt', function (e, settings, json, xhr) {
-        if (json) {
-            //update filter totals
-            $('#spAll').html(numberWithCommas(json.totalExternal + json.totalFederal));
-            $('#spFederal').html(numberWithCommas(json.totalFederal));
-            $('#spExternal').html(numberWithCommas(json.totalExternal));
-        }
     }).on('page.dt', function () {
         $(".dataTables_paginate").addClass("wait");
         $(":focus").blur();


### PR DESCRIPTION
Admin users have reported the following URLs do not load the page data:

https://dev-admin-jobboard.workbc.ca/jobs/JobSearch/Index
https://test-admin-jobboard.workbc.ca/jobs/JobSearch/Index 

But, the same page in PROD does load -- albeit slowly.

This PR remove queries that display total record counts at the top of the page.  If the page loads successfully after merging, we can create a new ticket to load the counts asynchronously.

