### PR TITLE
[WBCAMS-346] fix failing test version 2

### DIFF
--- a/src/WorkBC.ElasticSearch.Indexing/Services/XmlParsingServiceWanted.cs
+++ b/src/WorkBC.ElasticSearch.Indexing/Services/XmlParsingServiceWanted.cs
@@ -138,7 +138,7 @@ namespace WorkBC.ElasticSearch.Indexing.Services
                                     {
                                         decimal salaryAmount = decimal.Parse(salary.Attributes["value"].Value);
                                         job.Salary = salaryAmount;
-                                        job.SalarySummary = $"${salaryAmount:C0} annually";
+                                        job.SalarySummary = $"${salaryAmount:#,##0} annually";
                                     }
                                 }
                             }


### PR DESCRIPTION
It appears the number format shorthand `C0` works in Windows locally, but doesn't work when the unit tests are run from Docker.