### PR TITLE
[NOC-276] example of changes required for SSOT db connection

### DIFF
--- a/src/WorkBC.Data/JobBoardContext.cs
+++ b/src/WorkBC.Data/JobBoardContext.cs
@@ -139,9 +139,16 @@ namespace WorkBC.Data
             // indexes for sorting job seekers on the admin screen
 
             // Status
-            modelBuilder.Entity<JobSeeker>()
-                .HasIndex(x => new { x.AccountStatus, x.LastName, x.FirstName })
-                .IncludeProperties(x => new { x.Email });
+            /*    modelBuilder.Entity<JobSeeker>()
+                   .HasIndex(x => new { x.AccountStatus, x.LastName, x.FirstName })
+                   .IncludeProperties(modelBuilder.Entity<>(x => new { x.Email }));
+
+
+                *
+                * NpgsqlIndexBuilderExtensions.IncludeProperties(
+       modelBuilder.Entity<Blog>().HasIndex(f => f.Name),
+       f => f.Description);
+               
 
             // First Name
             modelBuilder.Entity<JobSeeker>()
@@ -167,6 +174,8 @@ namespace WorkBC.Data
             modelBuilder.Entity<JobSeeker>()
                 .HasIndex(x => new { x.DateRegistered })
                 .IncludeProperties(x => new { x.LastName, x.FirstName, x.Email, x.AccountStatus });
+                
+                 */
 
             modelBuilder
                 .Entity<AdminUser>()

--- a/src/WorkBC.Data/SsotContext.cs
+++ b/src/WorkBC.Data/SsotContext.cs
@@ -1,0 +1,208 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using WorkBC.Data.Model.Enterprise;
+
+namespace WorkBC.Data
+{
+    public partial class SsotContext : DbContext
+    {
+        private string ssotConnectionString;
+        
+        public SsotContext(DbContextOptions<SsotContext> options, IConfiguration configuration) 
+            : base(options)
+        {
+            ssotConnectionString = configuration.GetConnectionString("SsotConnection");
+        }
+
+        public virtual DbSet<CareerProfile> CareerProfiles { get; set; }
+        public virtual DbSet<IndustryProfile> IndustryProfiles { get; set; }
+        public virtual DbSet<Noc> Nocs { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseNpgsql(ssotConnectionString);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CareerProfile>(entity =>
+            {
+                entity.HasKey(e => e.CareerProfileId);
+
+                entity.ToTable("edm_careerprofile");
+
+                entity.HasIndex(e => e.NocId).IsUnique();
+                
+                entity.Property(e => e.CareerProfileId).HasColumnName("careerprofileid");
+
+                entity.Property(e => e.AnnualSalarySource).HasMaxLength(255);
+
+                entity.Property(e => e.CareerImage).HasColumnType("image");
+
+                entity.Property(e => e.CareerImageHeadShot).HasColumnType("image");
+
+                entity.Property(e => e.CareerLicensingId).HasColumnName("CareerLicensingID");
+
+                entity.Property(e => e.CareerOutlookTitle).HasMaxLength(255);
+
+                entity.Property(e => e.CareerTrekId)
+                    .HasColumnName("CareerTrekID")
+                    .HasMaxLength(11)
+                    .IsUnicode(false)
+                    .IsFixedLength();
+
+                entity.Property(e => e.CareerTrekImageUrl).HasColumnName("CareerTrekImageURL");
+
+                entity.Property(e => e.EstimatedTime).HasMaxLength(255);
+
+                entity.Property(e => e.HighDemandTitle).HasMaxLength(255);
+
+                entity.Property(e => e.HighOpportunityNocgroupNocId).HasColumnName("HighOpportunityNOCGroupNOC_ID");
+
+                entity.Property(e => e.IsFeatured).HasDefaultValueSql("((0))");
+
+                entity.Property(e => e.IsFeaturedCategory).HasDefaultValueSql("((0))");
+
+                entity.Property(e => e.MinimumEducation).HasMaxLength(250);
+
+                entity.Property(e => e.NocId).HasColumnName("noc_id");
+
+                entity.Property(e => e.PageDescription).HasMaxLength(300);
+
+                entity.Property(e => e.PageKeywords).HasMaxLength(135);
+
+                entity.Property(e => e.PageTitle).HasMaxLength(62);
+
+                entity.Property(e => e.RegionOutlookSummaryCar).HasColumnName("RegionOutlookSummaryCAR");
+
+                entity.Property(e => e.RegionOutlookSummaryKoo).HasColumnName("RegionOutlookSummaryKOO");
+
+                entity.Property(e => e.RegionOutlookSummaryMsw).HasColumnName("RegionOutlookSummaryMSW");
+
+                entity.Property(e => e.RegionOutlookSummaryNcn).HasColumnName("RegionOutlookSummaryNCN");
+
+                entity.Property(e => e.RegionOutlookSummaryNe).HasColumnName("RegionOutlookSummaryNE");
+
+                entity.Property(e => e.RegionOutlookSummaryTok).HasColumnName("RegionOutlookSummaryTOK");
+
+                entity.Property(e => e.RegionOutlookSummaryVi).HasColumnName("RegionOutlookSummaryVI");
+
+                entity.Property(e => e.RegionalEmploymentCarall).HasColumnName("RegionalEmploymentCARAll");
+
+                entity.Property(e => e.RegionalEmploymentCarthis).HasColumnName("RegionalEmploymentCARThis");
+
+                entity.Property(e => e.RegionalEmploymentKooall).HasColumnName("RegionalEmploymentKOOAll");
+
+                entity.Property(e => e.RegionalEmploymentKoothis).HasColumnName("RegionalEmploymentKOOThis");
+
+                entity.Property(e => e.RegionalEmploymentMswall).HasColumnName("RegionalEmploymentMSWAll");
+
+                entity.Property(e => e.RegionalEmploymentMswthis).HasColumnName("RegionalEmploymentMSWThis");
+
+                entity.Property(e => e.RegionalEmploymentNcnall).HasColumnName("RegionalEmploymentNCNAll");
+
+                entity.Property(e => e.RegionalEmploymentNcnthis).HasColumnName("RegionalEmploymentNCNThis");
+
+                entity.Property(e => e.RegionalEmploymentTokall).HasColumnName("RegionalEmploymentTOKAll");
+
+                entity.Property(e => e.RegionalEmploymentTokthis).HasColumnName("RegionalEmploymentTOKThis");
+
+                entity.Property(e => e.RegionalEmploymentViall).HasColumnName("RegionalEmploymentVIAll");
+
+                entity.Property(e => e.RegionalEmploymentVithis).HasColumnName("RegionalEmploymentVIThis");
+
+                entity.Property(e => e.SiteId)
+                    .HasColumnName("SiteID")
+                    .HasDefaultValueSql("((0))");
+
+                entity.Property(e => e.StatusId).HasColumnName("StatusID");
+
+                entity.Property(e => e.TotalApproximateFees).HasMaxLength(255);
+                
+            });
+
+            modelBuilder.Entity<IndustryProfile>(entity =>
+            {
+                entity.HasKey(e => e.IndustryProfileId);
+
+                entity.ToTable("edm_industryprofile");
+
+                entity.HasIndex(e => e.NaicsId)
+                    .IsUnique();
+
+                entity.Property(e => e.IndustryProfileId).HasColumnName("IndustryProfileID");
+
+                entity.Property(e => e.IndustryHeaderImage).HasColumnType("image");
+
+                entity.Property(e => e.IndustryImage).HasColumnType("image");
+
+                entity.Property(e => e.NaicsId).HasColumnName("NAICS_ID");
+
+                entity.Property(e => e.PageDescription).HasMaxLength(300);
+
+                entity.Property(e => e.PageKeywords).HasMaxLength(135);
+
+                entity.Property(e => e.PageTitle).HasMaxLength(62);
+            });
+
+            modelBuilder.Entity<Noc>(entity =>
+            {
+                entity.HasKey(e => e.NocId);
+
+                entity.ToTable("edm_noc");
+
+                entity.HasIndex(e => e.NocgroupTypeId);
+
+                entity.HasIndex(e => e.Nocs2006);
+
+                entity.Property(e => e.NocId).HasColumnName("noc_id");
+
+                entity.Property(e => e.EnglishShortAlias).HasMaxLength(200);
+
+                entity.Property(e => e.NameEnglish).HasMaxLength(200);
+
+                entity.Property(e => e.NameFrench).HasMaxLength(200);
+
+                entity.Property(e => e.NocId2006).HasColumnName("NOC_ID2006");
+
+                entity.Property(e => e.Noccode)
+                    .IsRequired()
+                    .HasColumnName("NOCCode")
+                    .HasMaxLength(4)
+                    .IsUnicode(false);
+
+                entity.Property(e => e.NocgroupTypeId).HasColumnName("NOCGroupTypeID");
+
+                entity.Property(e => e.Nocs2006)
+                    .HasColumnName("NOCS2006")
+                    .HasMaxLength(5)
+                    .IsUnicode(false);
+
+                entity.Property(e => e.Nocyear)
+                    .HasColumnName("NOCYear")
+                    .HasDefaultValueSql("((2006))");
+
+                entity.Property(e => e.ParentNocId).HasColumnName("ParentNOC_ID");
+
+                entity.Property(e => e.SkillLevel)
+                    .HasMaxLength(1)
+                    .IsUnicode(false)
+                    .IsFixedLength();
+
+                entity.Property(e => e.TradesOutlookNoc).HasColumnName("TradesOutlookNOC");
+
+                entity.HasOne(d => d.NocId2006Navigation)
+                    .WithMany(p => p.InverseNocId2006Navigation)
+                    .HasForeignKey(d => d.NocId2006);
+
+                entity.HasOne(d => d.ParentNoc)
+                    .WithMany(p => p.InverseParentNoc)
+                    .HasForeignKey(d => d.ParentNocId);
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}

--- a/src/WorkBC.Data/WorkBC.Data.csproj
+++ b/src/WorkBC.Data/WorkBC.Data.csproj
@@ -24,6 +24,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.9" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
 	<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />	  
   </ItemGroup>
 

--- a/src/WorkBC.Web/Controllers/CareerProfilesController.cs
+++ b/src/WorkBC.Web/Controllers/CareerProfilesController.cs
@@ -23,11 +23,11 @@ namespace WorkBC.Web.Controllers
     public class CareerProfilesController : ControllerBase
     {
         private readonly JobBoardContext _context;
-        private readonly EnterpriseContext _enterpriseContext;
+        private readonly SsotContext _enterpriseContext;
         private readonly IConfiguration _configuration;
         private readonly IGeocodingService _geocodingService;
 
-        public CareerProfilesController(JobBoardContext context, EnterpriseContext enterpriseContext,
+        public CareerProfilesController(JobBoardContext context, SsotContext enterpriseContext,
             IConfiguration configuration, IGeocodingService geocodingService)
         {
             _context = context;

--- a/src/WorkBC.Web/Controllers/IndustryProfilesController.cs
+++ b/src/WorkBC.Web/Controllers/IndustryProfilesController.cs
@@ -19,13 +19,13 @@ namespace WorkBC.Web.Controllers
     public class IndustryProfilesController : ControllerBase
     {
         private readonly JobBoardContext _context;
-        private readonly EnterpriseContext _enterpriseContext;
+        private readonly SsotContext _ssotContext;
         private readonly IConfiguration _configuration;
 
-        public IndustryProfilesController(JobBoardContext context, EnterpriseContext enterpriseContext, IConfiguration configurtion)
+        public IndustryProfilesController(JobBoardContext context, SsotContext ssotContext, IConfiguration configurtion)
         {
             _context = context;
-            _enterpriseContext = enterpriseContext;
+            _ssotContext = ssotContext;
             _configuration = configurtion;
         }
 
@@ -44,6 +44,7 @@ namespace WorkBC.Web.Controllers
         [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true, Duration = 0)]
         public async Task<ActionResult<IEnumerable<IndustryProfileModel>>> GetSavedIndustryProfilesAsync()
         {
+            Console.WriteLine("DEBUG - inside GetSavedIndustryProfilesAsync()");
             var savedIndustryProfiles = await _context.SavedIndustryProfiles
                 .Where(x => x.AspNetUserId == UserId && !x.IsDeleted)
                 .ToListAsync();
@@ -61,7 +62,7 @@ namespace WorkBC.Web.Controllers
             //    ? await GetIndustryIdsAndJobCounts()
             //    : new Dictionary<int, IndustryProfileModel>();
 
-            var query = from p in _enterpriseContext.IndustryProfiles
+            var query = from p in _ssotContext.IndustryProfiles
                         where savedIndustryProfilesDict.Keys.Contains(p.IndustryProfileId)
                         orderby p.PageTitle
                         select new IndustryProfileModel
@@ -103,7 +104,7 @@ namespace WorkBC.Web.Controllers
             var lstNaics = naicsId.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (string naics in lstNaics)
             {
-                int industryProfileId = (from profile in _enterpriseContext.IndustryProfiles
+                int industryProfileId = (from profile in _ssotContext.IndustryProfiles
                                          where profile.NaicsId == Convert.ToInt32(naics)
                                          select profile.IndustryProfileId).FirstOrDefault();
 
@@ -141,7 +142,7 @@ namespace WorkBC.Web.Controllers
         {
             //find the industry profile id based on the naics code
             int industryProfileId = (
-                from profile in _enterpriseContext.IndustryProfiles
+                from profile in _ssotContext.IndustryProfiles
                 where profile.NaicsId == naicsId
                 select profile.IndustryProfileId
             ).FirstOrDefault();

--- a/src/WorkBC.Web/Startup.cs
+++ b/src/WorkBC.Web/Startup.cs
@@ -72,6 +72,9 @@ namespace WorkBC.Web
                 options.UseSqlServer(
                     Configuration.GetConnectionString("EnterpriseConnection")),
                 ServiceLifetime.Transient);
+            
+            services.AddDbContext<SsotContext>(options =>
+                options.UseNpgsql(Configuration.GetConnectionString("SsotConnection")), ServiceLifetime.Transient);
 
             services.AddDefaultIdentity<JobSeeker>(options =>
             {

--- a/src/WorkBC.Web/WorkBC.Web.csproj
+++ b/src/WorkBC.Web/WorkBC.Web.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
     <PackageReference Include="NEST" Version="7.17.4" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />

--- a/src/WorkBC.Web/appsettings.json
+++ b/src/WorkBC.Web/appsettings.json
@@ -2,6 +2,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;integrated security=true;Database=WorkBC_JobBoard_DEV",
     "EnterpriseConnection": "Server=localhost;integrated security=true;Database=WorkBC_Enterprise_DEV",
+    "SsotConnection": "Host=localhost:5432;Username=x;Password=x;Database=ssot",
     "ElasticSearchServer": "http://localhost:9200",
     "Redis": "localhost"
   },


### PR DESCRIPTION
# Switch MSSQL Enterprise Database with Postgres SSOT

After exploring this option, I don't recommend this approach. Microsoft does not make it easy to switch from MSSQL to Postgres.  It feels like a game of whack-a-mole -- solve one problem and another crops up.  To date, I have been unable to get the JobBoardContext and the SSOTContext running simultaneously.  If we're forced to use this approach, we might consider a tool like Bablefish to emulate MSSQL using Postgres.