### PR TITLE
[Unsolicited] fix federal importer crash

### DIFF
--- a/src/WorkBC.Importers.Federal/Services/JobsTableSyncService.cs
+++ b/src/WorkBC.Importers.Federal/Services/JobsTableSyncService.cs
@@ -119,29 +119,32 @@ namespace WorkBC.Importers.Federal.Services
                     string xmlString = importedJob.JobPostEnglish;
 
                     ElasticSearchJob elasticJob = _xmlParsingService.ConvertToElasticJob(xmlString);
-
-                    bool needsNewVersion = CopyElasticJob(elasticJob, job);
-
-                    job.LastUpdated = elasticJob.LastUpdated ?? importedJob.DateLastImported;
-                    //job.DateFirstImported = importedJob.DateFirstImported;  /* Don't change DateFirstImported or it will mess up reports!! */
-                    job.DateLastImported = importedJob.DateLastImported;
-
-                    SetJobTypeFlags(xmlString, job);
-
-                    using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+                    
+                    if (elasticJob != null)
                     {
-                        if (needsNewVersion)
+                        bool needsNewVersion = CopyElasticJob(elasticJob, job);
+                        
+                        job.LastUpdated = elasticJob.LastUpdated ?? importedJob.DateLastImported;
+                        //job.DateFirstImported = importedJob.DateFirstImported;  /* Don't change DateFirstImported or it will mess up reports!! */
+                        job.DateLastImported = importedJob.DateLastImported;
+
+                        SetJobTypeFlags(xmlString, job);
+
+                        using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                         {
-                            IncrementJobVersion(job);
+                            if (needsNewVersion)
+                            {
+                                IncrementJobVersion(job);
+                            }
+
+                            DbContext.Jobs.Update(job);
+
+                            Console.Write("U");
+
+                            await DbContext.SaveChangesAsync();
+
+                            trans.Complete();
                         }
-
-                        DbContext.Jobs.Update(job);
-
-                        Console.Write("U");
-
-                        await DbContext.SaveChangesAsync();
-
-                        trans.Complete();
                     }
                 }
             }


### PR DESCRIPTION
When running the federal job importer locally, the import script crashes because of a missing null check.