### PR TITLE
[WBCAMS-184] fix job seeker report

### DIFF
--- a/src/WorkBC.Admin/Areas/Reports/Controllers/JobSeekerAccountController.cs
+++ b/src/WorkBC.Admin/Areas/Reports/Controllers/JobSeekerAccountController.cs
@@ -61,8 +61,16 @@ namespace WorkBC.Admin.Areas.Reports.Controllers
             // make sure the periods exists
             await _matrixReportService.EnsureWeeklyPeriodsExist(startDate, endDate);
 
-            // make sure the is data generated for the period
-            await _jobSeekerAccountReportService.GenerateJobSeekerStats(startDate, endDate);
+            /*
+            
+            The data required for this report is generated from a stored procedure
+            called, usp_GenerateJobSeekerStats.  The stored procedure is run on the
+            7th, 14th, 21st, 27th of each month plus the very last day of the month. 
+            It can be executed from the command line as follows:
+            
+            sqlcmd -S <computer-name>\<instance> -d '<database-name>' -q "EXEC dbo.usp_GenerateJobSeekerStats '2024-03-07'"
+            
+            */
 
             int maxPeriod = await _jobSeekerAccountReportService.GetMaxPeriod() ?? int.MaxValue;
 

--- a/src/WorkBC.Admin/Areas/Reports/Controllers/JobSeekerAccountController.cs
+++ b/src/WorkBC.Admin/Areas/Reports/Controllers/JobSeekerAccountController.cs
@@ -65,10 +65,13 @@ namespace WorkBC.Admin.Areas.Reports.Controllers
             
             The data required for this report is generated from a stored procedure
             called, usp_GenerateJobSeekerStats.  The stored procedure is run on the
-            7th, 14th, 21st, 27th of each month plus the very last day of the month. 
-            It can be executed from the command line as follows:
+            7th, 14th, 21st, 28th of each month plus the very last day of the month. 
+            It can be executed from PowerShell as follows:
             
-            sqlcmd -S <computer-name>\<instance> -d '<database-name>' -q "EXEC dbo.usp_GenerateJobSeekerStats '2024-03-07'"
+            sqlcmd -S <computer-name>\<instance> -d '<database-name>' -q "EXEC dbo.usp_GenerateJobSeekerStats '$([datetime]::now.tostring("yyyy-MM-dd"))'"
+            
+            From bash use:
+            sqlcmd -S <computer-name>\<instance> -d '<database-name>' -q "EXEC dbo.usp_GenerateJobSeekerStats '$(date +%F)'"
             
             */
 

--- a/src/WorkBC.Admin/Areas/Reports/Services/JobSeekerAccountReportService.cs
+++ b/src/WorkBC.Admin/Areas/Reports/Services/JobSeekerAccountReportService.cs
@@ -22,33 +22,6 @@ namespace WorkBC.Admin.Areas.Reports.Services
             _dapperContext = dapperContext;
         }
 
-        public async Task GenerateJobSeekerStats(DateTime startDate, DateTime endDate)
-        {
-            IList<WeeklyPeriod> weeklyPeriods =
-                await _jobBoardContext.WeeklyPeriods
-                    .Where(p => p.WeekStartDate >= startDate && p.WeekEndDate <= endDate &&
-                                p.WeekStartDate < DateTime.Now)
-                    .ToListAsync();
-
-            IList<int> weeklyPeriodIds = weeklyPeriods.Select(w => w.Id).ToList();
-
-            IList<ReportPersistenceControl> jobSeekerStatsPeriods =
-                await _jobBoardContext.ReportPersistenceControl
-                    .Where(period =>
-                        period.TableName == "JobSeekerStats" && 
-                        weeklyPeriodIds.Contains(period.WeeklyPeriodId) && !period.IsTotalToDate)
-                    .ToListAsync();
-
-            foreach (WeeklyPeriod period in weeklyPeriods)
-            {
-                if (jobSeekerStatsPeriods.All(j => j.WeeklyPeriodId != period.Id))
-                {
-                    // run the stored procedure to populate the missing data
-                    await _dapperContext.Persistence.GenerateJobSeekerStats(period.WeekEndDate);
-                }
-            }
-        }
-
         public MatrixReport GroupUsers(IList<JobSeekerAccountResult> results)
         {
             IEnumerable<IGrouping<string, JobSeekerAccountResult>> grouped = results.GroupBy(r => r.Label);


### PR DESCRIPTION
Remove stored procedure call.  Will run separately on a schedule instead.

## Deployment instructions:
 set up schedule to run `usp_GenerateJobSeekerStats` on the 7th, 14th, 21st, 28th and the very last day of the month. 