### PR TITLE
[WBCAMS-420] improve speed of federal jobs importer

### DIFF
--- a/src/WorkBC.Importers.Federal/WorkBC.Importers.Federal.csproj
+++ b/src/WorkBC.Importers.Federal/WorkBC.Importers.Federal.csproj
@@ -8,6 +8,7 @@
 	<Authors>OXD</Authors>
 	<Company>WorkBC</Company>
 	<Product>WorkBC Job Board</Product>
+    <Version>1.0.1</Version>
 	<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 

--- a/src/WorkBC.Tests/README.md
+++ b/src/WorkBC.Tests/README.md
@@ -2,4 +2,4 @@
 - Change directory to: `.\src`
 - Run the unit tests by using: 
 
-  ```dotnet test WorkBC.Tests/WorkBC.Tests.csproj -c Release,```
+  ```dotnet test WorkBC.Tests/WorkBC.Tests.csproj -c Release```


### PR DESCRIPTION
This pull request improves the speed of the federal job importer by ~50% when updating a job and by ~300% when importing a new job.  Key changes as follows:

 - reuse the HttpClient instead of creating a new copy on every request
 - call the french and english API endpoints simultaneously rather than sequentially
 
Some of these changes were incorporated into a previous commit (b6f06255) but then reverted (f9dc3115).