### PR TITLE
[WBCAMS-310] display expiry date consistently

### DIFF
--- a/src/WorkBC.Web/Services/SavedJobsService.cs
+++ b/src/WorkBC.Web/Services/SavedJobsService.cs
@@ -95,7 +95,7 @@ namespace WorkBC.Web.Services
                         {
                             City = j.City,
                             DatePosted = j.DatePosted,
-                            ExpireDate = j.ExpireDate,
+                            ExpireDate = j.ExpireDate.ToUniversalTime(),
                             EmployerName = j.EmployerName,
                             JobId = j.JobId,
                             Salary = j.Salary,


### PR DESCRIPTION
When the saved jobs are pulled from the database, they're currently passed to the front end without a time zone (see left screen below) whereas when the public job board pulls from ElasticSearch the data returned has a UTC timezone `+00:00` (see right screen below).

![Screenshot (36)](https://github.com/bcgov/workbc-jb/assets/25233684/3d1e2935-b62b-4909-b781-a2a54f3aa05d)

This PR sets a UTC timezone on the expiry date when returning the saved jobs so that the expiry date is treated consistently between the public facing job board and a job seekers saved jobs.  The screenshot below shows how the expiry date is received by the front end after this change is implemented.

![Screenshot (37)](https://github.com/bcgov/workbc-jb/assets/25233684/1f2a2246-8999-4377-b7fd-b919b06ff768)

