### PR TITLE
NOC-301-JobBoardIndexNOC2021

### DIFF
--- a/src/WorkBC.Data/JobBoardContext.cs
+++ b/src/WorkBC.Data/JobBoardContext.cs
@@ -87,6 +87,8 @@ namespace WorkBC.Data
 
         public DbSet<NocCode> NocCodes { get; set; }
 
+        public DbSet<NocCode2021> NocCodes2021 { get; set; }
+
         public DbSet<Province> Provinces { get; set; }
 
         public DbSet<Region> Regions { get; set; }

--- a/src/WorkBC.Data/Migrations/20240408233312_AddNocCodes2021.Designer.cs
+++ b/src/WorkBC.Data/Migrations/20240408233312_AddNocCodes2021.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WorkBC.Data;
 
@@ -11,9 +12,10 @@ using WorkBC.Data;
 namespace WorkBC.Data.Migrations
 {
     [DbContext(typeof(JobBoardContext))]
-    partial class JobBoardContextModelSnapshot : ModelSnapshot
+    [Migration("20240408233312_AddNocCodes2021")]
+    partial class AddNocCodes2021
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WorkBC.Data/Migrations/20240408233312_AddNocCodes2021.cs
+++ b/src/WorkBC.Data/Migrations/20240408233312_AddNocCodes2021.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WorkBC.Data.Migrations
+{
+    public partial class AddNocCodes2021 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NocCodes2021",
+                columns: table => new
+                {
+                    Id = table.Column<short>(type: "smallint", nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(5)", maxLength: 5, nullable: true),
+                    Title = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: true),
+                    FrenchTitle = table.Column<string>(type: "nvarchar(180)", maxLength: 180, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NocCodes2021", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NocCodes2021");
+        }
+    }
+}

--- a/src/WorkBC.Data/Model/JobBoard/NocCode2021.cs
+++ b/src/WorkBC.Data/Model/JobBoard/NocCode2021.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WorkBC.Data.Model.JobBoard
+{
+    public class NocCode2021
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        public short Id { get; set; }
+
+        [StringLength(5)]
+        public string Code { get; set; }
+
+        [StringLength(150)]
+        public string Title { get; set; }
+
+        [StringLength(180)]
+        public string FrenchTitle { get; set; }
+    }
+}


### PR DESCRIPTION
Changes for https://hive.aved.gov.bc.ca/jira/browse/NOC-376

Created a new JobBoard.NocCodes2021 table with the same schema as NocCodes, except that the Code model is a 5-digit string. 

Migration script to be run on Package Manager Console is as follows:
add-migration AddNocCodes2021 -context jobboardcontext
update-database -context jobboardcontext