### PR TITLE
[WBCAMS-415] stop deleted jobs from being reimported

### DIFF
--- a/src/WorkBC.Importers.Wanted/Services/JobsTableSyncService.cs
+++ b/src/WorkBC.Importers.Wanted/Services/JobsTableSyncService.cs
@@ -31,7 +31,9 @@ namespace WorkBC.Importers.Wanted.Services
         {
             List<long> jobsToImport = DbContext.ImportedJobsWanted
                 .Where(ij =>
-                    !ij.IsFederalOrWorkBc && DbContext.Jobs.All(j => j.JobId != ij.JobId) &&
+                    !ij.IsFederalOrWorkBc && 
+                    DbContext.Jobs.All(j => j.JobId != ij.JobId) &&
+                    DbContext.DeletedJobs.All(dj => dj.JobId != ij.JobId) &&
                     ij.ApiDate.AddDays(_jobExpiryDays) > DateTime.Now)
                 .Select(ij => ij.JobId)
                 .ToList();
@@ -120,6 +122,7 @@ namespace WorkBC.Importers.Wanted.Services
             List<long> jobsToUpdate = (from ij in DbContext.ImportedJobsWanted
                 join j in DbContext.Jobs on ij.JobId equals j.JobId
                 where !ij.IsFederalOrWorkBc 
+                      && DbContext.DeletedJobs.All(dj => dj.JobId != ij.JobId)
                       && (j.DateLastImported != ij.DateLastImported || !j.IsActive || _commandLineOptions.ReImport)
                 select ij.JobId).ToList();
 


### PR DESCRIPTION
When a job is deleted from by an admin, the job is re-imported when `WorkBC.Importers.Wanted` is next run.  This PR filters out deleted jobs from the wanted jobs importer so they can't be re-imported.