### PR TITLE
[NOC-333] Changes for adding Noc2021 data to Wanted importer and indexer

### DIFF
--- a/src/WorkBC.Data/Migrations/20240430195843_UpdateNocCodes2016Data.Designer.cs
+++ b/src/WorkBC.Data/Migrations/20240430195843_UpdateNocCodes2016Data.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WorkBC.Data;
 
@@ -11,9 +12,10 @@ using WorkBC.Data;
 namespace WorkBC.Data.Migrations
 {
     [DbContext(typeof(JobBoardContext))]
-    partial class JobBoardContextModelSnapshot : ModelSnapshot
+    [Migration("20240430195843_UpdateNocCodes2016Data")]
+    partial class UpdateNocCodes2016Data
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WorkBC.Data/Migrations/20240430195843_UpdateNocCodes2016Data.cs
+++ b/src/WorkBC.Data/Migrations/20240430195843_UpdateNocCodes2016Data.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text;
+using System;
+using WorkBC.Data.Model.Enterprise;
+
+#nullable disable
+
+namespace WorkBC.Data.Migrations
+{
+    public partial class UpdateNocCodes2016Data : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            //Add new columns to dbo.NocCodes2021 tables.
+            migrationBuilder.AddColumn<string>(
+            name: "Code2016",
+            table: "NocCodes2021",
+            type: "nvarchar(30)",
+            maxLength: 30,
+            nullable: true);
+
+            var allNocs = GetNocCodes2016();
+
+            foreach (var noc in allNocs)
+            {
+                if (!String.IsNullOrEmpty(noc.noc_2021))
+                {                    
+                    string code2016 = noc.noc_2016.ToString();
+
+                    //The field 'Id' is derived from the field 'Code' and is not an auto-generated Identity field.
+                    int.TryParse(noc.noc_2021.ToString(), out int id);
+
+                    //Updating Code2016 column in the table dbo.NocCodes2021.
+                    migrationBuilder.UpdateData(
+                    table: "NocCodes2021",
+                    keyColumn: "Id",
+                    keyValue: id,
+                    column: "Code2016",
+                    value: code2016);
+                }
+            }
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+            name: "Code2016",
+            table: "NocCodes2021");
+        }
+
+        public List<NocCodeSSOT1> GetNocCodes2016()
+        {
+
+            List<NocCodeSSOT1> newSSOTCodes = new List<NocCodeSSOT1>();
+            //Read the ssot_nocs json file from the path:~\workbc-jb\src\WorkBC.Web
+            string jsonString = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "ssot_nocs.json"));
+            // convert string to stream
+            byte[] byteArray = Encoding.UTF8.GetBytes(jsonString);
+            MemoryStream jsonStream = new MemoryStream(byteArray);
+
+            newSSOTCodes = JsonSerializer.Deserialize<List<NocCodeSSOT1>>(jsonStream);
+
+            return newSSOTCodes;
+
+        }
+    }
+
+    public class NocCodeSSOT1
+    {
+        public string noc_2021 { get; set; }
+        public string label { get; set; }
+        public string label_fr { get; set; }
+        public string noc_2016 { get; set; }
+
+    }
+}

--- a/src/WorkBC.Data/Model/JobBoard/NocCode2021.cs
+++ b/src/WorkBC.Data/Model/JobBoard/NocCode2021.cs
@@ -17,5 +17,8 @@ namespace WorkBC.Data.Model.JobBoard
 
         [StringLength(250)]
         public string FrenchTitle { get; set; }
+
+        [StringLength(30)]
+        public string Code2016 { get; set; }
     }
 }

--- a/src/WorkBC.ElasticSearch.Indexing/Services/JobsTableSyncServiceBase.cs
+++ b/src/WorkBC.ElasticSearch.Indexing/Services/JobsTableSyncServiceBase.cs
@@ -167,68 +167,6 @@ namespace WorkBC.ElasticSearch.Indexing.Services
             return newVersion;
         }
 
-        protected bool CopyElasticJobWanted(ElasticSearchJob elasticJob, Job job)
-        {
-            int locationId;
-            if (elasticJob.WorkplaceType?.Id == (int)WorkplaceTypeId.Virtual)
-            {
-                locationId = VirtualJobsLocationId;
-            }
-            else
-            {
-                if (elasticJob.City == null || elasticJob.City.Length == 0)
-                {
-                    locationId = 0;
-                }
-                else
-                {
-                    locationId = elasticJob.City.Length > 1
-                        ? MultipleLocationsId
-                        : GetBestAvailableLocationId(elasticJob.City[0]);
-                }
-            }
-
-
-            bool newVersion = job.NocCodeId != (short?)elasticJob.Noc
-                              || job.IndustryId != (short?)(elasticJob.NaicsId == 0 ? (int?)null : elasticJob.NaicsId)
-                              || job.LocationId != locationId
-                              || job.PositionsAvailable != (short)elasticJob.PositionsAvailable
-                              || job.DatePosted != elasticJob.DatePosted
-                              || job.ActualDatePosted != elasticJob.ActualDatePosted
-                              || !job.IsActive;
-
-
-            var code2016 = (short?)elasticJob.Noc;
-            // get the NoC Code 2021 value for the corresponding 2016 value.
-            var record = DbContext.NocCodes2021
-                .FirstOrDefault(n => n.Code2016.Contains(job.NocCodeId.ToString()));
-            string code2021 = new string(" ");
-            if (record != null)
-            {
-                code2021 = record.Code;
-
-                Console.WriteLine("code2021:" + code2021);
-
-                job.NocCodeId2021 = Convert.ToInt32(code2021 == " " ? 0 : code2021);
-            }
-
-            job.EmployerName = elasticJob.EmployerName.Truncate(100);
-            job.City = string.Join(", ", elasticJob.City ?? new string[] { }).Truncate(120);
-            job.Title = elasticJob.Title.Truncate(300);
-            job.NocCodeId = (short?)elasticJob.Noc;
-            job.DatePosted = elasticJob.DatePosted;
-            job.ActualDatePosted = elasticJob.ActualDatePosted;
-            job.ExpireDate = elasticJob.ExpireDate ?? DateTime.Now.AddDays(_wantedJobExpiryDays);
-            job.PositionsAvailable = (short)elasticJob.PositionsAvailable;
-            job.Salary = elasticJob.Salary;
-            job.SalarySummary = elasticJob.SalarySummary;
-            job.IndustryId = (short?)(elasticJob.NaicsId == 0 ? (int?)null : elasticJob.NaicsId);
-            job.LocationId = locationId;
-            job.IsActive = true;
-
-            return newVersion;
-        }
-
         protected void IncrementJobVersion(Job job)
         {
             DateTime now = DateTime.Now;
@@ -282,14 +220,14 @@ namespace WorkBC.ElasticSearch.Indexing.Services
                     JobSourceId = job.JobSourceId,
                     IndustryId = job.IndustryId,
                     NocCodeId = job.NocCodeId,
-                    NocCodeId2021 = job.NocCodeId2021,
+                    NocCodeId2021 = job.NocCodeId2021,                    
                     IsActive = true,
                     PositionsAvailable = job.PositionsAvailable,
                     LocationId = job.LocationId,
                     IsCurrentVersion = true,
                     VersionNumber = 1
                 };
-            }
+            }            
 
             DbContext.JobVersions.Add(newVersion);
         }

--- a/src/WorkBC.ElasticSearch.Indexing/Services/JobsTableSyncServiceBase.cs
+++ b/src/WorkBC.ElasticSearch.Indexing/Services/JobsTableSyncServiceBase.cs
@@ -36,7 +36,7 @@ namespace WorkBC.ElasticSearch.Indexing.Services
                 _wantedJobExpiryDays = configuration.GetSection("WantedSettings").Exists()
                     ? int.Parse(configuration["WantedSettings:JobExpiryDays"])
                     : General.DefaultWantedJobExpiryDays;
-            } 
+            }
             catch
             {
                 _wantedJobExpiryDays = General.DefaultWantedJobExpiryDays;
@@ -55,7 +55,7 @@ namespace WorkBC.ElasticSearch.Indexing.Services
                     select j).ToList();
             }
             else // jobSourceId == JobSource.Federal
-            { 
+            {
                 jobsToDeactivate = (from j in DbContext.Jobs
                     where j.JobSourceId == JobSource.Federal && j.IsActive &&
                           !(from ij in DbContext.ImportedJobsFederal select ij.JobId).Contains(j.JobId)
@@ -163,7 +163,7 @@ namespace WorkBC.ElasticSearch.Indexing.Services
             job.IndustryId = (short?)(elasticJob.NaicsId == 0 ? (int?)null : elasticJob.NaicsId);
             job.LocationId = locationId;
             job.IsActive = true;
-            
+
             return newVersion;
         }
 
@@ -206,7 +206,7 @@ namespace WorkBC.ElasticSearch.Indexing.Services
                     LocationId = job.LocationId,
                     IsCurrentVersion = true,
                     VersionNumber = (short) (oldVersion.VersionNumber + 1)
-                };                
+                };
             }
             else
             {
@@ -220,14 +220,14 @@ namespace WorkBC.ElasticSearch.Indexing.Services
                     JobSourceId = job.JobSourceId,
                     IndustryId = job.IndustryId,
                     NocCodeId = job.NocCodeId,
-                    NocCodeId2021 = job.NocCodeId2021,                    
+                    NocCodeId2021 = job.NocCodeId2021,
                     IsActive = true,
                     PositionsAvailable = job.PositionsAvailable,
                     LocationId = job.LocationId,
                     IsCurrentVersion = true,
                     VersionNumber = 1
                 };
-            }            
+            }
 
             DbContext.JobVersions.Add(newVersion);
         }
@@ -251,8 +251,8 @@ namespace WorkBC.ElasticSearch.Indexing.Services
                 return dateImported;
             }
 
-            return datePosted < dateImported.AddHours(-24) 
-                ? dateImported.AddHours(-24) 
+            return datePosted < dateImported.AddHours(-24)
+                ? dateImported.AddHours(-24)
                 : datePosted;
         }
 

--- a/src/WorkBC.ElasticSearch.Indexing/Services/XmlParsingServiceBase.cs
+++ b/src/WorkBC.ElasticSearch.Indexing/Services/XmlParsingServiceBase.cs
@@ -204,6 +204,41 @@ namespace WorkBC.ElasticSearch.Indexing.Services
             }
         }
 
+        protected int? GetNoc2021from2016value(string nocId)
+        {
+            int noc2021;
+            if (String.IsNullOrEmpty(nocId))
+            {
+                return null;
+            }         
+
+            try
+            {
+                // get the NoC Code 2021 value for the corresponding 2016 value.
+                string noc2021Str = (
+                        from nc in NocCodes2021
+                        where nc.Code2016.Contains(nocId)
+                        select nc.Code
+                    ).FirstOrDefault();
+
+                if (String.IsNullOrEmpty(noc2021Str))
+                {
+                    return null;
+                }
+                else
+                {
+                    noc2021 = Convert.ToInt32(noc2021Str);
+                }
+                return noc2021;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Exception in GetNoc2021from2016value(), reason: " + ex.Message);
+                Console.WriteLine("Noc2016: " + nocId);
+                return null;
+            }
+        }
+
         protected string ConvertToTime(decimal time)
         {
             //Possible values: 8, 8.3, 20

--- a/src/WorkBC.ElasticSearch.Indexing/Services/XmlParsingServiceWanted.cs
+++ b/src/WorkBC.ElasticSearch.Indexing/Services/XmlParsingServiceWanted.cs
@@ -275,6 +275,11 @@ namespace WorkBC.ElasticSearch.Indexing.Services
 
                             #endregion
 
+                            #region Noc code 2021                           
+                            //set job noc code 2021
+                            job.Noc2021 = GetNoc2021from2016value(job.Noc.ToString());
+                            #endregion
+
                             #region Job title
 
                             if (xmlJobNode.SelectSingleNode("title").Attributes["value"] != null &&

--- a/src/WorkBC.Importers.Wanted/Services/JobsTableSyncService.cs
+++ b/src/WorkBC.Importers.Wanted/Services/JobsTableSyncService.cs
@@ -140,7 +140,7 @@ namespace WorkBC.Importers.Wanted.Services
 
                     if (elasticJob?.JobId != null && job != null)
                     {
-                        bool needsNewVersion = CopyElasticJobWanted(elasticJob, job);
+                        bool needsNewVersion = CopyElasticJob(elasticJob, job);
 
                         job.LastUpdated = elasticJob.LastUpdated ?? importedJob.DateLastImported;
                         //job.DateFirstImported = importedJob.DateFirstImported;  /* Don't change DateFirstImported or it will mess up reports!! */

--- a/src/WorkBC.Importers.Wanted/Services/JobsTableSyncService.cs
+++ b/src/WorkBC.Importers.Wanted/Services/JobsTableSyncService.cs
@@ -140,7 +140,7 @@ namespace WorkBC.Importers.Wanted.Services
 
                     if (elasticJob?.JobId != null && job != null)
                     {
-                        bool needsNewVersion = CopyElasticJob(elasticJob, job);
+                        bool needsNewVersion = CopyElasticJobWanted(elasticJob, job);
 
                         job.LastUpdated = elasticJob.LastUpdated ?? importedJob.DateLastImported;
                         //job.DateFirstImported = importedJob.DateFirstImported;  /* Don't change DateFirstImported or it will mess up reports!! */

--- a/src/WorkBC.Tests/Fixtures/NocFixture.cs
+++ b/src/WorkBC.Tests/Fixtures/NocFixture.cs
@@ -12,6 +12,7 @@ namespace WorkBC.Tests.Fixtures
                 new NocCode2021 {Code = "74102", Code2016 = "7514", Id= 74102, Title= "Driver - Richmond"},
                 new NocCode2021 {Code = "52120", Code2016 = "5241", Id= 52120, Title= "Graphic Designer"},
                 new NocCode2021 {Code = "63200", Code2016 = "6322", Id= 63200, Title= "Cook"},
+                new NocCode2021 {Code = "11100", Code2016 = "1111,1114", Id= 11100, Title= "Financial insurance advisor"}
             };
         public static List<NocCode> NocCodes =>
             new List<NocCode>

--- a/src/WorkBC.Tests/Fixtures/NocFixture.cs
+++ b/src/WorkBC.Tests/Fixtures/NocFixture.cs
@@ -8,7 +8,10 @@ namespace WorkBC.Tests.Fixtures
         public static List<NocCode2021> NocCodes2021 =>
          new List<NocCode2021>
             {
-                new NocCode2021 {Code = "21234", Id= 21234, Title= "Web developers and programmers"},
+                new NocCode2021 {Code = "11202", Code2016 = "4163", Id= 21234, Title= "Web developers and programmers"},
+                new NocCode2021 {Code = "74102", Code2016 = "7514", Id= 74102, Title= "Driver - Richmond"},
+                new NocCode2021 {Code = "52120", Code2016 = "5241", Id= 52120, Title= "Graphic Designer"},
+                new NocCode2021 {Code = "63200", Code2016 = "6322", Id= 63200, Title= "Cook"},
             };
         public static List<NocCode> NocCodes =>
             new List<NocCode>

--- a/src/WorkBC.Tests/Fixtures/WantedXmlJobs/6178058670.xml
+++ b/src/WorkBC.Tests/Fixtures/WantedXmlJobs/6178058670.xml
@@ -1,0 +1,38 @@
+﻿<job id="6178058670" hash="2204234286" refnumber="" isstaffing="false" isanonymous="false" isthirdparty="false"
+     isinappropriate="false" isbulk="false" isaggregator="false" isfree="false" isclassifiedoccupation="true"
+     isclassifiedindustry="true" iscurrent="true">
+	<dates firstseen="2019-10-03" posted="2019-10-03" refreshed="2019-10-03" />
+	<title value="Digital Marketing Specialist - Bilingual" titleid="698109398" cleantitleid="12100081"
+		   semicleantitleid="37141148" />
+	<description
+	  value="Bilingual (French/English) Digital Marketing Specialist WE NEED Absolute Results is looking for a Bilingual Digital Marketing Specialist to join our fast-growing team in Surrey, BC. Reporting to the Senior Digital Marketing Lead, you will manage..." />
+	<occupation>
+		<noc code="7514" label="Driver - Richmond" revision="2011" />
+	</occupation>
+	<industry code="541618" label="Other Management Consulting Services" />
+	<function id="14" label="Marketing / PR" />
+	<employer id="1015954" name="ABSOLUTE RESULTS" superaliasid="1015954" superalias="ABSOLUTE RESULTS" />
+	<education id="5" label="Bachelor's degree" />
+	<locations>
+		<location>
+			<city code="5915004" label="Surrey" />
+			<state code="59" label="BC" />
+			<county code="5915" label="Greater Vancouver County" />
+			<wib id="0" code="00000" label="Unavailable" />
+			<msa code="59933" label="Vancouver" />
+			<position latitude="49.10810089111328" longitude="-122.7969970703125" />
+		</location>
+	</locations>
+	<salaries>
+		<salary id="2" type="Modeled" value="62000" />
+	</salaries>
+	<jobtypes>
+		<jobtype id="4" label="Full-Time" />
+		<jobtype id="1" label="Permanent" />
+	</jobtypes>
+	<tags />
+	<sources>
+		<source id="1572" jobid="6178058670" tags="" type="Corporate" name="ABSOLUTE RESULTS"
+				url="https://absoluteresults.bamboohr.com/jobs/view.php?id=30" validlink="true" />
+	</sources>
+</job>

--- a/src/WorkBC.Tests/Fixtures/WantedXmlJobs/6178210923.xml
+++ b/src/WorkBC.Tests/Fixtures/WantedXmlJobs/6178210923.xml
@@ -1,0 +1,39 @@
+﻿<job id="6178210923" hash="2204234286" refnumber="" isstaffing="false" isanonymous="false" isthirdparty="false"
+     isinappropriate="false" isbulk="false" isaggregator="false" isfree="false" isclassifiedoccupation="true"
+     isclassifiedindustry="true" iscurrent="true">
+	<dates firstseen="2019-10-03" posted="2019-10-03" refreshed="2019-10-03" />
+	<title value="Digital Marketing Specialist - Bilingual" titleid="698109398" cleantitleid="12100081"
+		   semicleantitleid="37141148" />
+	<description
+	  value="Bilingual (French/English) Digital Marketing Specialist WE NEED Absolute Results is looking for a Bilingual Digital Marketing Specialist to join our fast-growing team in Surrey, BC. Reporting to the Senior Digital Marketing Lead, you will manage..." />
+	<occupation>
+		<noc code="1111" label="Accountant" revision="2011" />
+		<noc code="1114" label="Financial insurance advisor" revision="2011" />
+	</occupation>
+	<industry code="541618" label="Other Management Consulting Services" />
+	<function id="14" label="Marketing / PR" />
+	<employer id="1015954" name="ABSOLUTE RESULTS" superaliasid="1015954" superalias="ABSOLUTE RESULTS" />
+	<education id="5" label="Bachelor's degree" />
+	<locations>
+		<location>
+			<city code="5915004" label="Surrey" />
+			<state code="59" label="BC" />
+			<county code="5915" label="Greater Vancouver County" />
+			<wib id="0" code="00000" label="Unavailable" />
+			<msa code="59933" label="Vancouver" />
+			<position latitude="49.10810089111328" longitude="-122.7969970703125" />
+		</location>
+	</locations>
+	<salaries>
+		<salary id="2" type="Modeled" value="62000" />
+	</salaries>
+	<jobtypes>
+		<jobtype id="4" label="Full-Time" />
+		<jobtype id="1" label="Permanent" />
+	</jobtypes>
+	<tags />
+	<sources>
+		<source id="1572" jobid="6178210923" tags="" type="Corporate" name="ABSOLUTE RESULTS"
+				url="https://absoluteresults.bamboohr.com/jobs/view.php?id=30" validlink="true" />
+	</sources>
+</job>

--- a/src/WorkBC.Tests/Tests/SearchTests.cs
+++ b/src/WorkBC.Tests/Tests/SearchTests.cs
@@ -76,9 +76,9 @@ namespace WorkBC.Tests.Tests
                 $"Job for NOC code {nocCode} did not return 3 results, but {result.Count} results");
         }
 
-        [Theory(DisplayName = "Find jobs based on a NOC code 2021")]
+        [Theory(DisplayName = "Find jobs based on a NOC code 2021 from a federal source")]
         [InlineData("21234")]
-        public async Task FindJobByNocCode2021(string nocCode2021)
+        public async Task FindJobByNocCode2021Federal(string nocCode2021)
         {
             //Create an instance with the filters required
             var esq = new JobSearchQuery(GeocodingService, Configuration, GetFiltersForJobNocField2021(nocCode2021));
@@ -94,7 +94,8 @@ namespace WorkBC.Tests.Tests
         [Theory(DisplayName = "Find jobs based on a NOC code 2021 derived from a TalentNeuron source")]
         [InlineData("11202")]
         [InlineData("74102")]
-        [InlineData("63200")]
+        [InlineData("52120")]
+        [InlineData("11100")]
         public async Task FindJobByNocCode2021Wanted(string nocCode2021)
         {
             //Create an instance with the filters required

--- a/src/WorkBC.Tests/Tests/SearchTests.cs
+++ b/src/WorkBC.Tests/Tests/SearchTests.cs
@@ -91,6 +91,23 @@ namespace WorkBC.Tests.Tests
                 $"Job for NOC code {nocCode2021} returned {result.Count} results");
         }
 
+        [Theory(DisplayName = "Find jobs based on a NOC code 2021 derived from a TalentNeuron source")]
+        [InlineData("11202")]
+        [InlineData("74102")]
+        [InlineData("63200")]
+        public async Task FindJobByNocCode2021Wanted(string nocCode2021)
+        {
+            //Create an instance with the filters required
+            var esq = new JobSearchQuery(GeocodingService, Configuration, GetFiltersForJobNocField2021(nocCode2021));
+
+            //return results
+            List<Source> result = await QueryElasticSearch(esq);
+
+            //We have 1 jobs with this NOC code in the fixtures
+            Assert.True(result.Count == 1,
+                $"Job for 2021 NOC code {nocCode2021} returned {result.Count} results");
+        }
+
         [Theory(DisplayName = "Find jobs based on job sources")]
         [InlineData("1")] //National Job Bank/WorkBC
         [InlineData("2")] //Other job posting websites (e.g. Monster, Workopolis, Indeed)

--- a/src/WorkBC.Tests/WorkBC.Tests.csproj
+++ b/src/WorkBC.Tests/WorkBC.Tests.csproj
@@ -82,6 +82,12 @@
     <None Update="Fixtures\WantedXmlJobs\4049816178.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+	<None Update="Fixtures\WantedXmlJobs\6178058670.xml">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</None>
+	<None Update="Fixtures\WantedXmlJobs\6178210923.xml">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changes include following:
1. At this time, the TalentNeuron API only provides a NOC 2011 code in its feed. In order to ingest jobs with the new NOC 2021 system, we have to map NOC 2011 codes to NOC 2021. Have added a migration to add a new column for 2016 codes in NocCodes2021 table and populate the cells with corresponding values in relation to their 2021 code values. It looks like below after implementation. The model does not need to convert from an array to string explicitly. While reading the JSON, we store the 2016 NocCode field as a comma separated string of values and then save the same string in DB.

2. This should be done by mapping from the incoming NOC code in the Wanted / TalentNeuron feed (which is a NOC 2011/2016 code) into a NOC 2021 code, using lookup from the NocCodes2021.NocCode2016 column - the first result is acceptable.

3. Ensured that the Wanted / Talent Neuron indexer picks up the new NOC 2021 field and indexes it the same way as the Federal Job feed indexer.

4. Added a unit test for verifying the Wanted importer job updates. 
