### PR TITLE
[WBCAMS-409] fix recommended jobs page error

### DIFF
--- a/src/WorkBC.Web/Services/RecommendedJobsService.cs
+++ b/src/WorkBC.Web/Services/RecommendedJobsService.cs
@@ -310,7 +310,7 @@ namespace WorkBC.Web.Services
 
             var reasons = new List<string>();
 
-            if (result.Noc != null)
+            if (!string.IsNullOrEmpty(result.Noc))
             {
                 short noc = short.Parse(result.Noc);
                 if (AccountCriteria.NocCodes.ContainsKey(noc))


### PR DESCRIPTION
Added a check for both null and empty Noc Codes to resolve an issue with the recommended jobs page.