### PR TITLE
WorkBC24-R3 Release V2 (TEST): Fix local configuration file

### DIFF
--- a/src/WorkBC.Indexers.Federal/appsettings.json
+++ b/src/WorkBC.Indexers.Federal/appsettings.json
@@ -9,7 +9,7 @@
     "ElasticPassword": ""
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;integrated security=true;Database=WorkBC_JobBoard_DEV"
+    "DefaultConnection": "Server=localhost;integrated security=true;Database=WorkBC_JobBoard_DEV",
     "ElasticSearchServer": "http://localhost:9200"
   },
   "ProxySettings": {


### PR DESCRIPTION
Some more details on the issue
The external jobs are posted for today
The last workBC job was posted July 16
The 'Date posted' filter for today shows 0 (something to do with the date stamp for external jobs maybe)?