### PR TITLE
Update DefaultWantedJobExpiryDays to 90

### DIFF
--- a/src/WorkBC.Shared/Constants/General.cs
+++ b/src/WorkBC.Shared/Constants/General.cs
@@ -1,11 +1,11 @@
-﻿namespace WorkBC.Shared.Constants
+namespace WorkBC.Shared.Constants
 {
     public class General
     {
         public const string SystemSettingsTimestampCacheKey = "SETTINGS_DT";
 
         public const int CacheMinutes = 60;
-        public const int DefaultWantedJobExpiryDays = 30;
+        public const int DefaultWantedJobExpiryDays = 90;
 
         //Elastic search index names
         public const string EnglishIndex = "jobs_en";


### PR DESCRIPTION

### Description
This PR updates the default job expiry period for Wanted job listings from 30 days to 90 days.
