### PR TITLE
fix(jb-search): prevent stale/unfiltered results from overriding filt…

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/services/filter.service.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/services/filter.service.ts
@@ -816,7 +816,7 @@ export class FilterService extends BaseService {
     this.update(mainFilters);
   }
 
-  removeAllTags() {
+  removeAllTags(silent = false) {
     //retrieve all current filters and remove all tags
     const mainFilters = this.currentFilter;
 
@@ -857,7 +857,12 @@ export class FilterService extends BaseService {
     //reset pagination
     mainFilters.pagination.currentPage = 1;
 
-    this.update(mainFilters);
+    // When called as part of restoring a bookmarkable URL, suppress this emission
+    // so we don't fire an extra (unfiltered) search before the filters are
+    // re-applied. setBookmarkableUrl() emits once via setFilters() afterwards.
+    if (!silent) {
+      this.update(mainFilters);
+    }
   }
 
   getScrollElement(): HTMLElement {
@@ -1370,13 +1375,17 @@ export class FilterService extends BaseService {
   }
 
   setBookmarkableUrl(params: Params, inJobAlert = false, path = ''): void {
-    //always clear the state before we set the bookmarks else the state will overwrite it
-    this.removeAllTags();
+    const hasParams =
+      params && !(Object.keys(params).length === 0 && params.constructor === Object);
+
+    //always clear the state before we set the bookmarks else the state will overwrite it.
+    //when params are present we suppress this emission (silent) so we don't fire an extra
+    //unfiltered search before the filters are re-applied - setFilters() emits the single
+    //search below once the full filter state has been restored.
+    this.removeAllTags(hasParams);
 
     if (params) {
-      if (
-        !(Object.keys(params).length === 0 && params.constructor === Object)
-      ) {
+      if (hasParams) {
         //loop through key/values
         for (const key in params) {
           //read value

--- a/src/WorkBC.Web/ClientApp/projects/jb-search/src/app/job-search/results/results.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-search/src/app/job-search/results/results.component.ts
@@ -4,6 +4,8 @@ import { Component, OnInit, ViewChild, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 
+import { switchMap } from 'rxjs/operators';
+
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { JobAlertComponent } from './job-alert/job-alert.component';
 import { MarkerClusterer, SuperClusterAlgorithm, Cluster, ClusterStats, Renderer } from '@googlemaps/markerclusterer';
@@ -174,40 +176,57 @@ export class ResultsComponent implements OnInit {
       this.filterService.setBookmarkableUrl(params);
     });
 
-    this.filterService.mainFilterModels$.subscribe(filter => {
-      this.loading = true;
+    // Use switchMap so that when the filter model changes again (e.g. during
+    // bookmarkable-URL restore on page load, which emits an empty model and then
+    // the fully-restored one), any in-flight search is cancelled and only the
+    // latest one updates the results. Without this, a plain nested subscribe
+    // leaves two uncancelled requests racing, and a slow unfiltered response can
+    // land after the filtered one - showing all jobs while the filter tags
+    // remain displayed.
+    this.filterService.mainFilterModels$.pipe(
+      switchMap(filter => {
+        this.loading = true;
 
-      //set local variable (for use later in maps)
-      this.mainFilterModel = filter;
+        //set local variable (for use later in maps)
+        this.mainFilterModel = filter;
 
-      //pass the filter to the results service
-      this.dataService.getResults(filter).subscribe(results => {
-
-        this.results = this.getJobs(results.result);
-
-        //total results
-        this.resultsCount = results.count;
-
-        // if the pagination is messed up then go back to page 1
-        if (this.results.length === 0 && results.count !== 0) {
-          this.mainFilterModel.pagination.currentPage = 1;
-          this.filterService.setFilters();
+        //refresh Google Maps results
+        if (this.showMap) {
+          //only refresh google map results if the map is currently showing,
+          //else this is not necessary as this will happen automatically when the map gets opened.
+          this.renderMap(true);
         }
 
-        //paging
-        this.paginationElement.setResultCount(this.resultsCount);
+        //pass the filter to the results service
+        return this.dataService.getResults(filter);
+      })
+    ).subscribe(results => {
 
-        this.urlParams = this.filterService.getUrlParams(this.location.path());
+      this.results = this.getJobs(results.result);
 
-        this.loading = false;
-      });
+      //total results
+      this.resultsCount = results.count;
 
-      //refresh Google Maps results
-      if (this.showMap) {
-        //only refresh google map results if the map is currently showing,
-        //else this is not necessary as this will happen automatically when the map gets opened.
-        this.renderMap(true);
+      // If the requested page is now out of range for the returned count, the
+      // page slice on screen no longer agrees with the count (e.g. a filter was
+      // applied while on page 2: the count drops but a stale/over-range page
+      // would otherwise keep showing rows beyond the new total). Clamp to the
+      // last valid page and re-fetch so the listed jobs always match the count.
+      const pageSize = +this.mainFilterModel.pagination.resultsPerPage || 20;
+      const currentPage = +this.mainFilterModel.pagination.currentPage || 1;
+      const lastValidPage = results.count > 0 ? Math.ceil(results.count / pageSize) : 1;
+      if (currentPage > lastValidPage) {
+        this.mainFilterModel.pagination.currentPage = lastValidPage;
+        this.filterService.setFilters();
+        return;
       }
+
+      //paging
+      this.paginationElement.setResultCount(this.resultsCount);
+
+      this.urlParams = this.filterService.getUrlParams(this.location.path());
+
+      this.loading = false;
     });
   }
 


### PR DESCRIPTION
…ered search

Two related job-board search defects caused by superseded searches leaving stale data on screen:

- On refresh, filter tags stayed but the unfiltered result set was shown. Root cause: setBookmarkableUrl emitted the model twice (empty model from removeAllTags, then the restored model), and the results stream used a plain nested subscribe with no cancellation, so the two searches raced and the late-arriving unfiltered response could win.
- With multiple filters, the listed jobs exceeded the reported count (e.g. count 23 but 35 listed across two pages). The count (track_total_hits) was correct; a stale over-range page slice from a previous search was still shown, and the existing guard only handled a fully-empty page.

Fixes (client-side only, no API change):
- results.component.ts: pipe mainFilterModels$ through switchMap so a newer search cancels any in-flight one.
- results.component.ts: clamp out-of-range pages - if currentPage exceeds ceil(count/pageSize), snap to the last valid page and refetch so listed jobs always match the count.
- filter.service.ts: removeAllTags(silent) - suppress the throwaway empty emission during URL restore so refresh fires a single (filtered) search.