### PR TITLE
Fix duplicate rows / wrong page slice in relevance federal-mix search

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/services/filter.service.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/filters/services/filter.service.ts
@@ -857,9 +857,8 @@ export class FilterService extends BaseService {
     //reset pagination
     mainFilters.pagination.currentPage = 1;
 
-    // When called as part of restoring a bookmarkable URL, suppress this emission
-    // so we don't fire an extra (unfiltered) search before the filters are
-    // re-applied. setBookmarkableUrl() emits once via setFilters() afterwards.
+    // silent skips this emission during URL restore so we don't fire an extra
+    // unfiltered search before the filters are re-applied.
     if (!silent) {
       this.update(mainFilters);
     }
@@ -1378,10 +1377,8 @@ export class FilterService extends BaseService {
     const hasParams =
       params && !(Object.keys(params).length === 0 && params.constructor === Object);
 
-    //always clear the state before we set the bookmarks else the state will overwrite it.
-    //when params are present we suppress this emission (silent) so we don't fire an extra
-    //unfiltered search before the filters are re-applied - setFilters() emits the single
-    //search below once the full filter state has been restored.
+    //always clear the state before we set the bookmarks else the state will overwrite it
+    //(silent when params exist so setFilters() below fires the single restored search).
     this.removeAllTags(hasParams);
 
     if (params) {

--- a/src/WorkBC.Web/ClientApp/projects/jb-search/src/app/job-search/results/results.component.ts
+++ b/src/WorkBC.Web/ClientApp/projects/jb-search/src/app/job-search/results/results.component.ts
@@ -176,13 +176,8 @@ export class ResultsComponent implements OnInit {
       this.filterService.setBookmarkableUrl(params);
     });
 
-    // Use switchMap so that when the filter model changes again (e.g. during
-    // bookmarkable-URL restore on page load, which emits an empty model and then
-    // the fully-restored one), any in-flight search is cancelled and only the
-    // latest one updates the results. Without this, a plain nested subscribe
-    // leaves two uncancelled requests racing, and a slow unfiltered response can
-    // land after the filtered one - showing all jobs while the filter tags
-    // remain displayed.
+    // switchMap cancels any in-flight search when the filter model changes again,
+    // so a slow superseded response can't override the latest results.
     this.filterService.mainFilterModels$.pipe(
       switchMap(filter => {
         this.loading = true;
@@ -207,11 +202,7 @@ export class ResultsComponent implements OnInit {
       //total results
       this.resultsCount = results.count;
 
-      // If the requested page is now out of range for the returned count, the
-      // page slice on screen no longer agrees with the count (e.g. a filter was
-      // applied while on page 2: the count drops but a stale/over-range page
-      // would otherwise keep showing rows beyond the new total). Clamp to the
-      // last valid page and re-fetch so the listed jobs always match the count.
+      // Clamp an out-of-range page to the last valid one so listed jobs match the count.
       const pageSize = +this.mainFilterModel.pagination.resultsPerPage || 20;
       const currentPage = +this.mainFilterModel.pagination.currentPage || 1;
       const lastValidPage = results.count > 0 ? Math.ceil(results.count / pageSize) : 1;

--- a/src/WorkBC.Web/Controllers/SearchController.cs
+++ b/src/WorkBC.Web/Controllers/SearchController.cs
@@ -380,10 +380,16 @@ namespace WorkBC.Web.Controllers
         }
 
         /// <summary>
-        ///     Run two relevance queries in parallel (federal-only and external-only) and
-        ///     interleave the results so each page contains at least 40% federal jobs while
-        ///     preserving relevance order within each stream. Falls back to padding from the
-        ///     other side when one source has fewer rows than its allocated slots.
+        ///     Run two relevance queries (federal-only and external-only) and interleave the
+        ///     results so each page contains at least 40% federal jobs while preserving relevance
+        ///     order within each stream.
+        ///
+        ///     Paging strategy: the interleave order is a deterministic function of the two
+        ///     relevance-sorted streams, so we fetch enough rows from each source to cover
+        ///     everything consumed up to AND including the requested page, rebuild the global
+        ///     interleave from row 0, then slice out the requested page. This keeps page
+        ///     boundaries consistent (no duplicates, no skipped rows) and naturally fills a full
+        ///     page from a single source when the other is empty (all-federal / all-external).
         /// </summary>
         private async Task<ElasticSearchResponse> GetFederalMixedResults(JobSearchFilters filters, string index)
         {
@@ -391,25 +397,26 @@ namespace WorkBC.Web.Controllers
 
             int pageSize = filters.PageSize > 0 ? filters.PageSize : 20;
             int pageNumber = filters.Page > 0 ? filters.Page : 1;
-            int federalSlots = (int)Math.Ceiling(pageSize * federalShare);
-            int externalSlots = pageSize - federalSlots;
+
+            // Rows we must materialise to be able to slice the requested page. Fetch from row 0
+            // for both sources (Skip stays 0) and cap each fetch at the cumulative page end so
+            // either source alone can fill every page if the other is empty.
+            int rowsThroughPage = pageSize * pageNumber;
 
             var federalQuery = new JobSearchQuery(_geocodingService, _configuration, filters)
             {
                 SearchJobSource = "1",
-                // Step pages by federalSlots (Skip = (pageNumber-1) * RequestedPageSize) but
-                // over-fetch a full page so we can pad if external runs short.
-                RequestedPageSize = federalSlots,
-                PageSize = pageSize,
-                PageNumber = pageNumber
+                RequestedPageSize = rowsThroughPage,
+                PageSize = rowsThroughPage,
+                PageNumber = 1
             };
 
             var externalQuery = new JobSearchQuery(_geocodingService, _configuration, filters)
             {
                 SearchJobSource = "2",
-                RequestedPageSize = externalSlots > 0 ? externalSlots : pageSize,
-                PageSize = pageSize,
-                PageNumber = pageNumber
+                RequestedPageSize = rowsThroughPage,
+                PageSize = rowsThroughPage,
+                PageNumber = 1
             };
 
             // Run sequentially — both queries call _geocodingService.GetLocation()
@@ -422,22 +429,27 @@ namespace WorkBC.Web.Controllers
             long fedTotal = fedResults?.Hits?.Total?.Value ?? 0;
             long extTotal = extResults?.Hits?.Total?.Value ?? 0;
 
-            var merged = new List<Hit>(pageSize);
+            // Build the global interleave from row 0 using a per-page slot allocation
+            // (federalShare of each page reserved for federal, padded from the other source
+            // when a stream runs short). Deterministic given the two ordered streams.
+            int federalSlotsPerPage = (int)Math.Ceiling(pageSize * federalShare);
+            var interleaved = new List<Hit>(fedHits.Count + extHits.Count);
             int fi = 0, ei = 0;
-            while (merged.Count < pageSize)
+            while (fi < fedHits.Count || ei < extHits.Count)
             {
-                bool federalSlotOpen = merged.Count < federalSlots && fi < fedHits.Count;
+                int slotInPage = interleaved.Count % pageSize;
+                bool federalSlotOpen = slotInPage < federalSlotsPerPage && fi < fedHits.Count;
                 if (federalSlotOpen)
                 {
-                    merged.Add(fedHits[fi++]);
+                    interleaved.Add(fedHits[fi++]);
                 }
                 else if (ei < extHits.Count)
                 {
-                    merged.Add(extHits[ei++]);
+                    interleaved.Add(extHits[ei++]);
                 }
                 else if (fi < fedHits.Count)
                 {
-                    merged.Add(fedHits[fi++]);
+                    interleaved.Add(fedHits[fi++]);
                 }
                 else
                 {
@@ -445,12 +457,18 @@ namespace WorkBC.Web.Controllers
                 }
             }
 
+            // Slice out the requested page.
+            int skip = (pageNumber - 1) * pageSize;
+            List<Hit> pageHits = skip < interleaved.Count
+                ? interleaved.GetRange(skip, Math.Min(pageSize, interleaved.Count - skip))
+                : new List<Hit>();
+
             // Reuse whichever response object exists so we don't have to construct
             // sealed/internal-ctor types (Hits, Total). Mutate its hits + total in place.
             ElasticSearchResponse merge = fedResults ?? extResults;
             if (merge?.Hits != null)
             {
-                merge.Hits.HitsHits = merged;
+                merge.Hits.HitsHits = pageHits;
                 if (merge.Hits.Total != null)
                 {
                     merge.Hits.Total.Value = fedTotal + extTotal;

--- a/src/WorkBC.Web/Controllers/SearchController.cs
+++ b/src/WorkBC.Web/Controllers/SearchController.cs
@@ -380,16 +380,10 @@ namespace WorkBC.Web.Controllers
         }
 
         /// <summary>
-        ///     Run two relevance queries (federal-only and external-only) and interleave the
-        ///     results so each page contains at least 40% federal jobs while preserving relevance
-        ///     order within each stream.
-        ///
-        ///     Paging strategy: the interleave order is a deterministic function of the two
-        ///     relevance-sorted streams, so we fetch enough rows from each source to cover
-        ///     everything consumed up to AND including the requested page, rebuild the global
-        ///     interleave from row 0, then slice out the requested page. This keeps page
-        ///     boundaries consistent (no duplicates, no skipped rows) and naturally fills a full
-        ///     page from a single source when the other is empty (all-federal / all-external).
+        ///     Interleave federal-only and external-only relevance results so each page holds at
+        ///     least 40% federal jobs. Both streams are fetched from row 0 through the requested
+        ///     page, interleaved deterministically, then the page is sliced out — so pages never
+        ///     duplicate or skip rows, and one source fills a full page when the other is empty.
         /// </summary>
         private async Task<ElasticSearchResponse> GetFederalMixedResults(JobSearchFilters filters, string index)
         {
@@ -397,10 +391,6 @@ namespace WorkBC.Web.Controllers
 
             int pageSize = filters.PageSize > 0 ? filters.PageSize : 20;
             int pageNumber = filters.Page > 0 ? filters.Page : 1;
-
-            // Rows we must materialise to be able to slice the requested page. Fetch from row 0
-            // for both sources (Skip stays 0) and cap each fetch at the cumulative page end so
-            // either source alone can fill every page if the other is empty.
             int rowsThroughPage = pageSize * pageNumber;
 
             var federalQuery = new JobSearchQuery(_geocodingService, _configuration, filters)
@@ -419,8 +409,7 @@ namespace WorkBC.Web.Controllers
                 PageNumber = 1
             };
 
-            // Run sequentially — both queries call _geocodingService.GetLocation()
-            // which uses DbContext, and DbContext is not thread-safe.
+            // Sequential: both queries use the non-thread-safe DbContext via GetLocation().
             ElasticSearchResponse fedResults = await federalQuery.GetSearchResults(index: index);
             ElasticSearchResponse extResults = await externalQuery.GetSearchResults(index: index);
 
@@ -429,9 +418,6 @@ namespace WorkBC.Web.Controllers
             long fedTotal = fedResults?.Hits?.Total?.Value ?? 0;
             long extTotal = extResults?.Hits?.Total?.Value ?? 0;
 
-            // Build the global interleave from row 0 using a per-page slot allocation
-            // (federalShare of each page reserved for federal, padded from the other source
-            // when a stream runs short). Deterministic given the two ordered streams.
             int federalSlotsPerPage = (int)Math.Ceiling(pageSize * federalShare);
             var interleaved = new List<Hit>(fedHits.Count + extHits.Count);
             int fi = 0, ei = 0;
@@ -457,14 +443,12 @@ namespace WorkBC.Web.Controllers
                 }
             }
 
-            // Slice out the requested page.
             int skip = (pageNumber - 1) * pageSize;
             List<Hit> pageHits = skip < interleaved.Count
                 ? interleaved.GetRange(skip, Math.Min(pageSize, interleaved.Count - skip))
                 : new List<Hit>();
 
-            // Reuse whichever response object exists so we don't have to construct
-            // sealed/internal-ctor types (Hits, Total). Mutate its hits + total in place.
+            // Reuse an existing response to avoid constructing the sealed Hits/Total types.
             ElasticSearchResponse merge = fedResults ?? extResults;
             if (merge?.Hits != null)
             {


### PR DESCRIPTION
GetFederalMixedResults built the federal sub-query with RequestedPageSize = federalSlots but PageSize = full page, desyncing ES 'from' (driven by RequestedPageSize) from 'size' (PageSize). On page 2+ the federal stream re-fetched rows already shown on page 1, producing duplicate listings. The total count was correct, so the UI showed 'Found N' while listing more than N rows across pages (e.g. Vancouver + full-time + industry 34: count=29 but 20+20 listed with 12 duplicates).

Rebuild the interleave deterministically from row 0 for both relevance-sorted streams, fetch enough rows to cover through the requested page, then slice the page out. This eliminates duplicates and skipped rows across pages, keeps the count exact, and lets a single source fill a full page when the other is empty (all-federal case).