### PR TITLE
Innovibe: remap NOC 00011-00015 to 00018 (NOC-387)

### DIFF
--- a/src/WorkBC.Importers.Innovibe/README.md
+++ b/src/WorkBC.Importers.Innovibe/README.md
@@ -88,6 +88,17 @@ duplicate-hash check on `JobPostEnglish` makes re-runs safe.
 The console output uses single-character markers per job (`I`/`U`/`S`/`H`/`E`)
 for compact log lines.
 
+### NOC 2021 code handling
+
+The highest-scored `nocMatches[].code` is taken, then **validated against the
+`"NocCodes2021"` table**; codes not present become `NULL` (the `NocCodeId2021`
+FK is nullable). Before validation, NOC-387 consolidation applies: the granular
+"Legislative and senior managers" unit groups **00011–00015 are remapped to
+00018** (*Senior managers - public and private sector*), because WorkBC
+standardizes on the consolidated 00018 and the individual 00011–00015 codes are
+intentionally absent from `"NocCodes2021"`. This mirrors `specialNocs` in
+`WorkBC.ElasticSearch.Indexing/Services/XmlParsingServiceFederal.cs`.
+
 ## Database (existing schema — no migrations owned here)
 
 | Table | Purpose |

--- a/src/WorkBC.Importers.Innovibe/src/Service/JobImportService.php
+++ b/src/WorkBC.Importers.Innovibe/src/Service/JobImportService.php
@@ -534,6 +534,14 @@ final class JobImportService
             $code = $nocMatches[0]['code'] ?? null;
             if ($code !== null) {
                 $candidate = (int) $code;
+                // NOC-387: consolidate the granular "Legislative and senior managers"
+                // unit groups 00011-00015 into 00018 (Senior managers - public and
+                // private sector) before validating. WorkBC standardizes on the
+                // consolidated 00018; the official 00011-00015 codes are not in
+                // NocCodes2021. Mirrors XmlParsingServiceFederal.cs (specialNocs).
+                if (in_array($candidate, [11, 12, 13, 14, 15], true)) {
+                    $candidate = 18;
+                }
                 if ($this->isValidNoc2021($candidate)) {
                     $nocCode2021 = $candidate;
                 }


### PR DESCRIPTION
The Innovibe feed emits the granular Statistics Canada NOC 2021 "Legislative and senior managers" unit groups (00011-00015), but NocCodes2021 only stores the consolidated 00018 (Senior managers - public and private sector). Jobs with e.g. 00012 therefore validated to NULL and imported unclassified (off the 00018 career profile).

Add the same consolidation the Federal indexer already does (XmlParsingServiceFederal.cs specialNocs): remap 00011-00015 -> 00018 in JobImportService::map() before validating against NocCodes2021.

Fixes go-forward imports. Already-imported NULL rows that the API no longer returns (back-dated active jobs, same window limitation as WBCAMS-2013) cannot be re-mapped by --bulk and need a one-off SQL backfill, handled separately outside this repo.