### PR TITLE
Migrate the Innovibe (Wanted) Indexer from .NET to PHP (WorkBC.Indexe…

### DIFF
--- a/.github/workflows/build-noc.yml
+++ b/.github/workflows/build-noc.yml
@@ -118,10 +118,10 @@ jobs:
         run: |
           docker push ${{ secrets.AWS_ECR_URI }}/jb-cli-innovibe:${{ github.sha }}
           
-      - name: Tag the Wanted Indexer docker image
+      - name: Tag the Innovibe Indexer V2 (PHP) docker image
         run: |
-          docker tag src_indexers-wanted:latest ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
-      - name: Push the Wanted Indexer docker image
+          docker tag src_indexers-innovibe-v2:latest ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
+      - name: Push the Innovibe Indexer V2 (PHP) docker image
         run: |
           docker push ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
           

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -123,10 +123,10 @@ jobs:
         run: |
           docker push ${{ secrets.AWS_ECR_URI }}/jb-cli-innovibe:${{ github.sha }}
           
-      - name: Tag the Wanted Indexer docker image
+      - name: Tag the Innovibe Indexer V2 (PHP) docker image
         run: |
-          docker tag src_indexers-wanted:latest ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
-      - name: Push the Wanted Indexer docker image
+          docker tag src_indexers-innovibe-v2:latest ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
+      - name: Push the Innovibe Indexer V2 (PHP) docker image
         run: |
           docker push ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,10 +122,10 @@ jobs:
         run: |
           docker push ${{ secrets.AWS_ECR_URI }}/jb-cli-innovibe:${{ github.sha }}
           
-      - name: Tag the Wanted Indexer docker image
+      - name: Tag the Innovibe Indexer V2 (PHP) docker image
         run: |
-          docker tag src_indexers-wanted:latest ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
-      - name: Push the Wanted Indexer docker image
+          docker tag src_indexers-innovibe-v2:latest ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
+      - name: Push the Innovibe Indexer V2 (PHP) docker image
         run: |
           docker push ${{ secrets.AWS_ECR_URI }}/jb-indexers-wanted:${{ github.sha }}
           

--- a/src/WorkBC.Indexers.Innovibe.V2/.dockerignore
+++ b/src/WorkBC.Indexers.Innovibe.V2/.dockerignore
@@ -1,0 +1,11 @@
+.env
+.env.*
+.git
+.gitignore
+.dockerignore
+.idea
+.vscode
+vendor
+README.md
+docker-compose*
+Dockerfile*

--- a/src/WorkBC.Indexers.Innovibe.V2/.env.example
+++ b/src/WorkBC.Indexers.Innovibe.V2/.env.example
@@ -1,0 +1,28 @@
+# Database connection (must match the PostgreSQL instance used by the rest of WorkBC)
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=jobboard
+DB_USER=
+DB_PASSWORD=
+
+# Elasticsearch / OpenSearch (read path is shared with the .NET search API)
+ELASTIC_URL=http://elasticsearch:9200
+ELASTIC_USER=
+ELASTIC_PASSWORD=
+
+# Index names (defaults match WorkBC.Shared.Constants.General).
+# Wanted documents are written to INDEX_EN only; INDEX_FR is recreated by
+# --reindex maintenance (the shared index-recreate touches both indexes).
+INDEX_EN=jobs_en
+INDEX_FR=jobs_fr
+
+# Days added to a job's refreshed date to compute ExpireDate
+# (General.DefaultWantedJobExpiryDays).
+WANTED_JOB_EXPIRY_DAYS=90
+
+# Per-request HTTP timeout (seconds) and the single-retry pause (ms) on an ES transport error.
+HTTP_TIMEOUT=30
+RETRY_DELAY_MS=15000
+
+# Logging: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL=INFO

--- a/src/WorkBC.Indexers.Innovibe.V2/.gitignore
+++ b/src/WorkBC.Indexers.Innovibe.V2/.gitignore
@@ -1,0 +1,25 @@
+# Dependencies
+/vendor/
+composer.lock
+
+# Environment / secrets
+.env
+.env.local
+.env.*.local
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# PHP
+*.phar
+
+# Docker overrides
+docker-compose.override.yml

--- a/src/WorkBC.Indexers.Innovibe.V2/Dockerfile
+++ b/src/WorkBC.Indexers.Innovibe.V2/Dockerfile
@@ -1,0 +1,31 @@
+# ── Build stage ──────────────────────────────────────────────────
+FROM php:8.3-cli-alpine AS build
+
+RUN apk add --no-cache postgresql-dev libxml2-dev autoconf gcc g++ make unzip \
+    && docker-php-ext-install pdo_pgsql dom simplexml
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+COPY composer.json ./
+RUN composer install --no-dev --no-interaction --optimize-autoloader --prefer-dist
+COPY src/ src/
+COPY resources/ resources/
+
+# ── Runtime stage ────────────────────────────────────────────────
+FROM php:8.3-cli-alpine
+
+RUN apk add --no-cache postgresql-libs libxml2 tzdata \
+    && apk add --no-cache --virtual .bd postgresql-dev libxml2-dev \
+    && docker-php-ext-install pdo_pgsql dom simplexml \
+    && apk del .bd \
+    && cp /usr/share/zoneinfo/America/Vancouver /etc/localtime \
+    && echo "America/Vancouver" > /etc/timezone
+
+WORKDIR /app
+COPY --from=build /app/vendor vendor/
+COPY --from=build /app/src src/
+COPY --from=build /app/resources resources/
+COPY php.ini /usr/local/etc/php/conf.d/php.ini
+
+ENTRYPOINT ["php", "src/index.php"]

--- a/src/WorkBC.Indexers.Innovibe.V2/README.md
+++ b/src/WorkBC.Indexers.Innovibe.V2/README.md
@@ -1,0 +1,139 @@
+# WorkBC.Indexers.Innovibe.V2
+
+PHP 8.3 indexer that reads external (Innovibe) job postings from the
+`"ImportedJobsWanted"` staging table and writes the corresponding documents into
+Elasticsearch (`jobs_en`). Packaged as a Docker image and scheduled via a
+Kubernetes CronJob.
+
+This is **stage 2** of the external-jobs pipeline (the **indexer**). Stage 1 (the
+**importer** that fetches the Innovibe API into `"ImportedJobsWanted"`) is
+`WorkBC.Importers.Innovibe`. This project is a PHP rewrite of the legacy .NET
+`WorkBC.Indexers.Wanted` + the JSON half of the shared
+`WorkBC.ElasticSearch.Indexing` library — it removes the last .NET dependency in
+the external-jobs indexing path.
+
+Innovibe is the only source of external jobs and its staging payloads are always
+JSON, so only the JSON mapping is ported (the legacy TalentNeuron XML branch is
+intentionally dropped — there is no live XML data).
+
+The Elasticsearch document shape is **functionally equivalent** to the .NET
+indexer: PascalCase field names exactly as defined by
+`resources/jobs_index.json.template`, with null-valued fields omitted (mirrors
+Newtonsoft `NullValueHandling.Ignore`).
+
+## Where it runs in production
+
+| Resource | Identifier |
+|---|---|
+| Image | `${ECR}/jb-indexers-wanted:<sha>` (now built from this PHP project) |
+| Built by | `.github/workflows/build*.yml` (compose service `indexers-innovibe-v2`) |
+| Tagged by | `.github/workflows/tag*.yml` (test → prod promotion) |
+| Wired by | `.github/workflows/deploy-*.{yml,yaml}` (`IMAGE7`) |
+| Cron | `cronjob/jb-importer-indexer`, container `wanted-indexer` |
+
+> The ECR repo / CronJob container keep the legacy **"wanted"** name to avoid
+> touching the Kubernetes objects (which live outside this repo). Only the source
+> project is renamed to "Innovibe" for clarity.
+
+It is also baked into the shared `php-cli` shell image (`cli2` / `jb-cli-innovibe`)
+at `/app/workbc-indexers-innovibe-v2`, alongside the federal indexer and the two
+PHP importers, for manual runs via `kubectl exec`.
+
+## Project Structure
+
+```
+WorkBC.Indexers.Innovibe.V2/
+├── src/
+│   ├── Config/AppConfig.php                # Env-var configuration (no geocoding/proxy).
+│   ├── Elastic/ElasticClient.php           # Guzzle ES wrapper: PUT/DELETE docs, create/delete
+│   │                                       #   index, close/open, scroll JobIds by source.
+│   ├── Json/InnovibeDocumentMapper.php     # JSON → ES document (PascalCase, nulls omitted).
+│   ├── Service/InnovibeIndexService.php    # Orchestrator: index loop, publishable gate,
+│   │                                       #   FlushRejected, clear-flag, purge, debug.
+│   ├── Service/IndexMaintenanceService.php # --reindex (drop+create+flag), --reopen.
+│   └── index.php                           # CLI entry point.
+├── resources/                              # ES index mapping + synonym templates (##SYNONYM##).
+├── Dockerfile                              # Multi-stage Alpine build (PHP 8.3 + pdo_pgsql).
+├── .env.example
+├── composer.json                           # monolog, guzzle, vlucas/phpdotenv.
+├── php.ini
+└── README.md
+```
+
+## Index Flow
+
+A normal run, mirroring the legacy `WorkBC.Indexers.Wanted/Program.cs`:
+
+1. **Index** — `SELECT` every `"ImportedJobsWanted"` row where
+   `"ReIndexNeeded" = TRUE AND "IsFederalOrWorkBc" = FALSE`; for each, build the
+   document from the Innovibe JSON and `PUT {ELASTIC_URL}/jobs_en/_doc/{JobId}`.
+   - **Publishable gate** — a job missing a Title, EmployerName, valid Noc2021, or
+     City is *not* indexed. It is parked: upserted into `"ExpiredJobs"` and flipped
+     `"IsActive" = FALSE` in `"Jobs"` so admin counts stop tracking it.
+   - On a transport error a single retry runs after `RETRY_DELAY_MS`; a persistent
+     ES failure stops the loop (it is almost certainly down).
+2. **Purge** — runs on every non-`--reindex` run:
+   - drain `"ExpiredJobs"` rows not yet `RemovedFromElasticsearch` (DELETE, mark);
+   - sweep orphans — any non-federal doc in ES whose `JobId` is no longer in
+     `"ImportedJobsWanted"` is deleted.
+
+### Document construction
+
+`InnovibeDocumentMapper` ports the JSON branch of the legacy
+`XmlParsingServiceWanted`: BC-preferred location + city/region disambiguation;
+salary annual conversion (HOUR×2080 / WEEK×52 / MONTH×12) with min–max range
+summary; `employmentType` → HoursOfWork / PeriodOfEmployment; 3-strategy education
+mapping; NOC 2021 from the highest-scored `nocMatches` (validated against
+`"NocCodes2021"`); title cleanup (strip U+200B, all-caps → lowercase,
+`\bpt\b`→PT / `\bft\b`→FT); `ExternalSource`; and `SalarySort`.
+
+## Database (existing schema — no migrations owned here)
+
+| Table | Purpose |
+|---|---|
+| `"ImportedJobsWanted"` | Staging — raw Innovibe JSON; `ReIndexNeeded` drives the loop; `IsFederalOrWorkBc=FALSE` selects Innovibe rows. |
+| `"ExpiredJobs"` | Archive — drained to remove ES documents; also receives publishable-gate rejects. |
+| `"Jobs"` | Reject path flips `IsActive=FALSE`; `--debug` diffs ES vs SQL. |
+| `"NocCodes2021"` | NOC validation + 2021 group titles. |
+| `"Locations"` / `"Regions"` | City → region / duplicate-city disambiguation. |
+
+This indexer does **not** create or alter tables.
+
+## Configuration
+
+| Var | Default | Notes |
+|---|---|---|
+| `DB_HOST`,`DB_PORT`,`DB_NAME`,`DB_USER`,`DB_PASSWORD` | postgres/5432/jobboard | Postgres connection. |
+| `ELASTIC_URL` | `http://elasticsearch:9200` | Elasticsearch / OpenSearch root. |
+| `ELASTIC_USER`,`ELASTIC_PASSWORD` | — | Basic auth (leave empty for none). |
+| `INDEX_EN`,`INDEX_FR` | `jobs_en` / `jobs_fr` | Documents go to `INDEX_EN`; `INDEX_FR` is only recreated by `--reindex`. |
+| `WANTED_JOB_EXPIRY_DAYS` | `90` | Days added to the refreshed date to compute `ExpireDate`. |
+| `HTTP_TIMEOUT` | `30` | Per-request timeout (s). |
+| `RETRY_DELAY_MS` | `15000` | Pause before the single retry on an ES transport error. |
+| `LOG_LEVEL` | `INFO` | DEBUG/INFO/WARNING/ERROR/CRITICAL. |
+
+## CLI Flags
+
+| Flag | Purpose |
+|---|---|
+| *(none)* | Index pending jobs, then purge. The daily cron path. |
+| `-r` / `--reindex` | Drop + recreate `jobs_en`/`jobs_fr`, flag all staging rows, then index (no purge). |
+| `-o` / `--reopen` | Close + reopen both indexes to reload the synonym file. |
+| `-n` / `--noreindex` | Skip the indexing loop (purge still runs). |
+| `-d` / `--debug` | Print the active-in-ES vs active-in-`Jobs` JobId diff and exit. |
+
+## Build & Run
+
+```bash
+# From src/
+docker compose build indexers-innovibe-v2
+docker compose run --rm indexers-innovibe-v2 -r   # recreate + reindex all
+docker compose run --rm indexers-innovibe-v2      # index pending + purge
+
+# Manual run from the cli2 / php-cli pod
+kubectl exec -it <php-cli-pod> -- bash
+cd /app/workbc-indexers-innovibe-v2
+php src/index.php            # index pending + purge
+php src/index.php -r         # recreate + reindex all
+php src/index.php -d         # debug diff
+```

--- a/src/WorkBC.Indexers.Innovibe.V2/composer.json
+++ b/src/WorkBC.Indexers.Innovibe.V2/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "workbc/innovibe-job-indexer",
+    "description": "WorkBC Innovibe Job Indexer – reads ImportedJobsWanted and writes Elasticsearch documents (PHP rewrite of WorkBC.Indexers.Wanted)",
+    "type": "project",
+    "require": {
+        "php": ">=8.3",
+        "ext-dom": "*",
+        "ext-libxml": "*",
+        "ext-pdo": "*",
+        "ext-pdo_pgsql": "*",
+        "ext-simplexml": "*",
+        "monolog/monolog": "^3.5",
+        "guzzlehttp/guzzle": "^7.9",
+        "vlucas/phpdotenv": "^5.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "WorkBC\\InnovibeJobIndexer\\": "src/"
+        }
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    }
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/php.ini
+++ b/src/WorkBC.Indexers.Innovibe.V2/php.ini
@@ -1,0 +1,5 @@
+; Custom PHP configuration for the Federal CLI indexer
+; A full --reindex walks every federal staging row and builds two ES documents each.
+memory_limit = 1024M
+default_socket_timeout = 60
+date.timezone = America/Vancouver

--- a/src/WorkBC.Indexers.Innovibe.V2/resources/jobs_index.json.template
+++ b/src/WorkBC.Indexers.Innovibe.V2/resources/jobs_index.json.template
@@ -1,0 +1,683 @@
+{
+  "settings": {
+    "number_of_shards": 1,
+    "analysis": {
+      "analyzer": {
+        "default": {
+          "tokenizer": "standard",
+          "filter": [
+            "asciifolding",
+            "english_possessive_stemmer",
+            "lowercase",
+            "english_stop",
+            "english_stemmer",
+            "synonym"
+          ]
+        },
+        "english_exact": {
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase"
+          ]
+        }
+      },
+      "filter": {
+        ##SYNONYM##,
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        },
+        "english_stemmer": {
+          "type": "stemmer",
+          "language": "light_english"
+        },
+        "english_possessive_stemmer": {
+          "type": "stemmer",
+          "language": "possessive_english"
+        }
+      },
+      "normalizer": {
+        "lowercase_normalizer": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": [ "lowercase", "asciifolding" ]
+        }
+      }
+    },
+    "index": {
+      "max_result_window": 50000
+    }
+  },
+  "mappings": {
+    "properties": {
+      "DatePosted": {
+        "type": "date"
+      },
+      "ExpireDate": {
+        "type": "date"
+      },
+      "StartDate": {
+        "type": "date"
+      },
+      "EduLevel": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "EmployerName": {
+        "type": "text",
+        "fields": {
+          "normalize": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "exact": {
+            "type": "text",
+            "analyzer": "english_exact"
+          }
+        }
+      },
+      "JobDescription": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "exact": {
+            "type": "text",
+            "analyzer": "english_exact"
+          }
+        }
+      },
+      "EmployerTypeId": {
+        "type": "long"
+      },
+      "IsAboriginal": {
+        "type": "boolean"
+      },
+      "IsApprentice": {
+        "type": "boolean"
+      },
+      "IsDisability": {
+        "type": "boolean"
+      },
+      "IsNewcomer": {
+        "type": "boolean"
+      },
+      "IsStudent": {
+        "type": "boolean"
+      },
+      "IsVeteran": {
+        "type": "boolean"
+      },
+      "IsVismin": {
+        "type": "boolean"
+      },
+      "IsYouth": {
+        "type": "boolean"
+      },
+      "IsMatureWorker": {
+        "type": "boolean"
+      },
+      "IsVariousLocation": {
+        "type": "boolean"
+      },
+      "JobId": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "LocationGeo": {
+        "type": "geo_point"
+      },
+      "Location": {
+        "properties": {
+          "Lat": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "Lon": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
+      "City": {
+        "type": "text",
+        "fields": {
+          "normalize": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "exact": {
+            "type": "text",
+            "analyzer": "english_exact"
+          }
+        }
+      },
+      "Province": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "Region": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "Function": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "Industry": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "Occupation": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "Lang": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "PostalCode": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "Salary": {
+        "type": "float"
+      },
+
+      "Noc2021": {
+        "type": "float"
+      },
+      "NocGroup": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "NocJobTitle": {
+        "type": "text",
+        "fields": {
+          "normalize": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "exact": {
+            "type": "text",
+            "analyzer": "english_exact"
+          }
+        }
+      },
+      "SkillCategories": {
+        "type": "nested",
+        "properties": {
+          "Category": {
+            "properties": {
+              "Id": {
+                "type": "long"
+              },
+              "Name": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
+          },
+          "SkillCount": {
+            "type": "long"
+          },
+          "Skills": {
+            "type": "text",
+            "copy_to": "AllSkills",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
+      "Title": {
+        "type": "text",
+        "fields": {
+          "normalize": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "exact": {
+            "type": "text",
+            "analyzer": "english_exact"
+          }
+        }
+      },
+      "WageClass": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "WorkHours": {
+        "type": "float"
+      },
+      "HoursOfWork": {
+        "properties": {
+          "Description": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
+      "PeriodOfEmployment": {
+        "properties": {
+          "Description": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
+      "EmploymentTerms": {
+        "properties": {
+          "Description": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
+      "SalaryConditions": {
+        "properties": {
+          "Description": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      },
+      "IsFederalJob": {
+        "type": "boolean"
+      },
+      "LastUpdated": {
+        "type": "date"
+      },
+      "PositionsAvailable": {
+        "type": "long"
+      },
+      "ApplyEmailAddress": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPhoneNumber": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPhoneNumberExt": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPhoneNumberTimeFrom": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPhoneNumberTimeTo": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyFaxNumber": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyWebsite": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "SalaryDescription": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "SalarySummary": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ProgramName": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ProgramDescription": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPersonStreet": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPersonRoom": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPersonCity": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPersonProvince": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPersonPostalCode": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPersonTimeFrom": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyPersonTimeTo": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyMailStreet": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyMailRoom": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyMailCity": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyMailProvince": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "ApplyMailPostalCode": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "NaicsId": {
+        "type": "integer"
+      },
+      "AllSkills": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "exact": {
+            "type": "text",
+            "analyzer": "english_exact"
+          }
+        }
+      },
+      "SalarySort": {
+        "properties": {
+          "Ascending": {
+            "type": "float"
+          },
+          "Descending": {
+            "type": "float"
+          }
+        }
+      },
+      "ExternalSource": {
+        "type": "nested",
+        "properties": {
+          "Source": {
+            "properties": {
+              "Url": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "Source": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "WorkplaceType": {
+        "properties": {
+          "Id": {
+            "type": "long"
+          },
+          "Description": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/resources/synonym_file.json.template
+++ b/src/WorkBC.Indexers.Innovibe.V2/resources/synonym_file.json.template
@@ -1,0 +1,4 @@
+"synonym": {
+  "type": "synonym",
+  "synonyms_path": "analysis/synonym.txt"
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/resources/synonym_predefined.json.template
+++ b/src/WorkBC.Indexers.Innovibe.V2/resources/synonym_predefined.json.template
@@ -1,0 +1,7 @@
+"synonym" : {
+    "type" : "synonym",
+    "synonyms" : [
+        "janitor, custodian",
+        "hairdresser, hairstylist"
+    ]
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/src/Config/AppConfig.php
+++ b/src/WorkBC.Indexers.Innovibe.V2/src/Config/AppConfig.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkBC\InnovibeJobIndexer\Config;
+
+/**
+ * Strongly-typed env-var configuration for the Wanted/Innovibe V2 indexer.
+ *
+ * Mirrors the legacy C# appsettings sections consumed by
+ * WorkBC.Indexers.Wanted / WorkBC.ElasticSearch.Indexing:
+ *   - ConnectionStrings:DefaultConnection   → DB_*
+ *   - ConnectionStrings:ElasticSearchServer → ELASTIC_URL
+ *   - IndexSettings:DefaultIndex            → INDEX_EN (documents are written here)
+ *   - IndexSettings:ElasticUser/Password    → ELASTIC_USER / ELASTIC_PASSWORD
+ *   - WantedSettings:JobExpiryDays          → WANTED_JOB_EXPIRY_DAYS
+ *
+ * Unlike the Federal indexer the Wanted path needs no geocoding (lat/lon come
+ * straight from the Innovibe JSON), so there is no Google Maps / proxy config.
+ * Wanted documents are written to a single index (INDEX_EN); INDEX_FR is only
+ * used by the shared --reindex maintenance which recreates both indexes.
+ */
+final class AppConfig
+{
+    public readonly string $dbDsn;
+    public readonly string $dbUser;
+    public readonly string $dbPassword;
+
+    public readonly string $elasticUrl;
+    public readonly string $elasticUser;
+    public readonly string $elasticPassword;
+
+    public readonly string $indexEn;
+    public readonly string $indexFr;
+
+    public readonly int $wantedJobExpiryDays;
+
+    public readonly int $httpTimeout;
+    public readonly int $retryDelayMs;
+
+    public readonly string $logLevel;
+
+    public function __construct()
+    {
+        $host = $this->env('DB_HOST', 'postgres');
+        $port = $this->env('DB_PORT', '5432');
+        $name = $this->env('DB_NAME', 'jobboard');
+        $this->dbDsn = "pgsql:host={$host};port={$port};dbname={$name}";
+        $this->dbUser = $this->env('DB_USER', 'workbc');
+        $this->dbPassword = $this->env('DB_PASSWORD', 'workbc');
+
+        $this->elasticUrl = rtrim($this->env('ELASTIC_URL', 'http://elasticsearch:9200'), '/');
+        $this->elasticUser = $this->env('ELASTIC_USER', '');
+        $this->elasticPassword = $this->env('ELASTIC_PASSWORD', '');
+
+        $this->indexEn = $this->env('INDEX_EN', 'jobs_en');
+        $this->indexFr = $this->env('INDEX_FR', 'jobs_fr');
+
+        // Matches General.DefaultWantedJobExpiryDays (90). The C# parser adds this
+        // many days to the refreshed date to compute ExpireDate.
+        $this->wantedJobExpiryDays = max(1, (int) $this->env('WANTED_JOB_EXPIRY_DAYS', '90'));
+
+        $this->httpTimeout = max(5, (int) $this->env('HTTP_TIMEOUT', '30'));
+        // Matches the 15s pause the C# PostToElasticSearch() waits on a
+        // WebException before retrying.
+        $this->retryDelayMs = max(0, (int) $this->env('RETRY_DELAY_MS', '15000'));
+
+        $this->logLevel = strtoupper($this->env('LOG_LEVEL', 'INFO'));
+    }
+
+    private function env(string $key, string $default = ''): string
+    {
+        $value = $_ENV[$key] ?? getenv($key);
+        if ($value === false || $value === null || $value === '') {
+            return $default;
+        }
+        return trim((string) $value);
+    }
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/src/Elastic/ElasticClient.php
+++ b/src/WorkBC.Indexers.Innovibe.V2/src/Elastic/ElasticClient.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkBC\InnovibeJobIndexer\Elastic;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Monolog\Logger;
+use WorkBC\InnovibeJobIndexer\Config\AppConfig;
+
+/**
+ * Thin Guzzle wrapper around the Elasticsearch HTTP API.
+ *
+ * Ports the ES-touching bits of the legacy C#:
+ *   - ElasticRequestService     (PUT / DELETE / POST with basic auth, proxy bypass)
+ *   - CreateIndexService        (read jobs_index.json, substitute ##SYNONYM##)
+ *   - DeleteIndexService        (DELETE index)
+ *   - ReIndexingService         (_close / _open to reload synonyms)
+ *   - IndexCheckerService       (scroll query to list indexed federal JobIds)
+ *
+ * Document type is "_doc" (General.ElasticDocType). The ES host is always
+ * addressed directly (no forward proxy), matching the C# WebProxy
+ * BypassProxyOnLocal behaviour.
+ */
+final class ElasticClient
+{
+    private const DOC_TYPE = '_doc';
+    private const SCROLL_TTL = '1m';
+    private const SCROLL_PAGE = 5000;
+
+    private Client $http;
+    private string $server;
+    private string $resourceDir;
+
+    public function __construct(
+        private readonly AppConfig $config,
+        private readonly Logger $log,
+    ) {
+        $this->server = $config->elasticUrl;
+        $this->resourceDir = dirname(__DIR__, 2) . '/resources';
+
+        $options = [
+            'base_uri' => $this->server . '/',
+            'timeout' => $config->httpTimeout,
+            'http_errors' => false,
+            // Never route Elasticsearch traffic through the forward proxy.
+            'proxy' => ['no' => ['*']],
+        ];
+        if ($config->elasticUser !== '') {
+            $options['auth'] = [$config->elasticUser, $config->elasticPassword];
+        }
+
+        $this->http = new Client($options);
+    }
+
+    // ── Document operations ────────────────────────────────────────
+
+    /**
+     * PUT a single document. Returns the lowercase ES result string
+     * ("created" / "updated") on success, or "error" on any failure.
+     */
+    public function putDocument(string $index, string $id, string $json): string
+    {
+        try {
+            $response = $this->http->put($this->docPath($index, $id), [
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $json,
+            ]);
+        } catch (GuzzleException $e) {
+            $this->log->error("ES PUT {$index}/{$id} transport error: {$e->getMessage()}");
+            return 'error';
+        }
+
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            $this->log->warning("ES PUT {$index}/{$id} returned HTTP {$status}: "
+                . substr((string) $response->getBody(), 0, 500));
+            return 'error';
+        }
+
+        $body = json_decode((string) $response->getBody(), true);
+        $result = is_array($body) && isset($body['result']) ? (string) $body['result'] : 'ok';
+        return strtolower($result);
+    }
+
+    /**
+     * DELETE a single document. A 404 (already gone) is treated as success.
+     */
+    public function deleteDocument(string $index, string $id): bool
+    {
+        try {
+            $response = $this->http->delete($this->docPath($index, $id));
+        } catch (GuzzleException $e) {
+            $this->log->error("ES DELETE {$index}/{$id} transport error: {$e->getMessage()}");
+            return false;
+        }
+        $status = $response->getStatusCode();
+        return ($status >= 200 && $status < 300) || $status === 404;
+    }
+
+    // ── Index maintenance ──────────────────────────────────────────
+
+    /**
+     * Recreate an index from resources/jobs_index.json.template, substituting
+     * the ##SYNONYM## placeholder with the contents of
+     * synonym_file.json.template (production) or
+     * synonym_predefined.json.template (unit-test style).
+     *
+     * These resources carry a ".template" suffix because they are NOT valid
+     * JSON on their own — the ##SYNONYM## placeholder (and the bare-entry
+     * synonym fragments) only become valid once substituted here. The suffix
+     * keeps JSON validators / IDEs from flagging them.
+     */
+    public function createIndex(string $index, bool $useSynonymFile = true): bool
+    {
+        $structure = $this->readResource('jobs_index.json.template');
+        $synonyms = $useSynonymFile
+            ? $this->readResource('synonym_file.json.template')
+            : $this->readResource('synonym_predefined.json.template');
+        $structure = str_replace('##SYNONYM##', $synonyms, $structure);
+
+        try {
+            $response = $this->http->put($index, [
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $structure,
+            ]);
+        } catch (GuzzleException $e) {
+            $this->log->error("ES create index {$index} transport error: {$e->getMessage()}");
+            return false;
+        }
+
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            $this->log->error("Failed to create index {$this->server}/{$index} (HTTP {$status}): "
+                . substr((string) $response->getBody(), 0, 500));
+            return false;
+        }
+        return true;
+    }
+
+    /** DELETE an index. A 404 (doesn't exist) is treated as success. */
+    public function deleteIndex(string $index): bool
+    {
+        try {
+            $response = $this->http->delete($index);
+        } catch (GuzzleException $e) {
+            $this->log->warning("ES delete index {$index} transport error: {$e->getMessage()}");
+            return false;
+        }
+        $status = $response->getStatusCode();
+        if ($status === 404) {
+            $this->log->info("Index {$index} was not removed (it probably doesn't exist)");
+            return true;
+        }
+        return $status >= 200 && $status < 300;
+    }
+
+    /** Close then re-open an index to trigger a synonym-file reload. */
+    public function closeAndReopen(string $index): void
+    {
+        foreach (['_close', '_open'] as $action) {
+            try {
+                $this->http->post("{$index}/{$action}");
+            } catch (GuzzleException $e) {
+                $this->log->warning("ES {$action} on {$index} failed: {$e->getMessage()}");
+            }
+        }
+    }
+
+    // ── Read path (purge support) ──────────────────────────────────
+
+    /**
+     * Scroll the whole index and return every JobId for the given source
+     * (IsFederalJob = $isFederal). Mirrors the IndexCheckerService
+     * GetIndexed / GetActive helpers (the Wanted indexer uses $isFederal=false).
+     *
+     * @return list<string>
+     */
+    public function getJobIdsBySource(string $index, bool $isFederal, bool $excludeExpired = false): array
+    {
+        $query = $excludeExpired
+            ? [
+                'bool' => [
+                    'must' => [['term' => ['IsFederalJob' => $isFederal]]],
+                    'filter' => [
+                        'range' => [
+                            'ExpireDate' => ['gte' => 'now', 'time_zone' => 'America/Vancouver'],
+                        ],
+                    ],
+                ],
+            ]
+            : ['term' => ['IsFederalJob' => $isFederal]];
+
+        $body = json_encode([
+            'size' => self::SCROLL_PAGE,
+            '_source' => ['JobId'],
+            'query' => $query,
+        ]);
+
+        $ids = [];
+        try {
+            $response = $this->http->post("{$index}/_search?scroll=" . self::SCROLL_TTL, [
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $body,
+            ]);
+            $decoded = json_decode((string) $response->getBody(), true);
+            $scrollId = $decoded['_scroll_id'] ?? null;
+            $hits = $decoded['hits']['hits'] ?? [];
+
+            while (!empty($hits)) {
+                foreach ($hits as $hit) {
+                    if (isset($hit['_id'])) {
+                        $ids[] = (string) $hit['_id'];
+                    }
+                }
+
+                if ($scrollId === null) {
+                    break;
+                }
+
+                $scrollResponse = $this->http->post('_search/scroll', [
+                    'headers' => ['Content-Type' => 'application/json'],
+                    'body' => json_encode(['scroll' => self::SCROLL_TTL, 'scroll_id' => $scrollId]),
+                ]);
+                $decoded = json_decode((string) $scrollResponse->getBody(), true);
+                $scrollId = $decoded['_scroll_id'] ?? $scrollId;
+                $hits = $decoded['hits']['hits'] ?? [];
+            }
+
+            if ($scrollId !== null) {
+                $this->clearScroll($scrollId);
+            }
+        } catch (GuzzleException $e) {
+            $this->log->error("getFederalJobIds({$index}) failed: {$e->getMessage()}");
+        }
+
+        return $ids;
+    }
+
+    private function clearScroll(string $scrollId): void
+    {
+        try {
+            $this->http->delete('_search/scroll', [
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => json_encode(['scroll_id' => [$scrollId]]),
+            ]);
+        } catch (GuzzleException) {
+            // Best-effort cleanup; the scroll context expires on its own.
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────
+
+    private function docPath(string $index, string $id): string
+    {
+        return $index . '/' . self::DOC_TYPE . '/' . rawurlencode($id);
+    }
+
+    private function readResource(string $name): string
+    {
+        $path = $this->resourceDir . '/' . $name;
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new \RuntimeException("Unable to read resource file: {$path}");
+        }
+        return $contents;
+    }
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/src/Json/InnovibeDocumentMapper.php
+++ b/src/WorkBC.Indexers.Innovibe.V2/src/Json/InnovibeDocumentMapper.php
@@ -1,0 +1,719 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkBC\InnovibeJobIndexer\Json;
+
+use Monolog\Logger;
+use PDO;
+
+/**
+ * Converts an Innovibe job JSON payload into the Elasticsearch document
+ * (the PascalCase shape defined by ElasticSearchJob.cs + jobs_index.json).
+ *
+ * Faithful port of the JSON branch of
+ * WorkBC.ElasticSearch.Indexing.Services.XmlParsingServiceWanted
+ * (ConvertJsonToElasticJob) plus the shared XmlParsingServiceBase helpers.
+ *
+ * Innovibe is the only source of external (Wanted) jobs and its payloads are
+ * always JSON — the legacy TalentNeuron XML branch is intentionally not ported.
+ *
+ * Null-valued fields are stripped just before serialization (mirrors the C#
+ * NullValueHandling.Ignore), so this mapper leaves nulls in place.
+ */
+final class InnovibeDocumentMapper
+{
+    /** Sentinel coordinates the feed uses for "unknown"; remapped to BC centroid. */
+    private const SENTINEL_LAT = '54.5000992';
+    private const SENTINEL_LON = '-125.1159973';
+
+    /** @var array<int,array{title:?string,frenchTitle:?string}>|null */
+    private ?array $nocGroups2021 = null;
+    /** @var array<string,string>|null  lower-case city name → region label */
+    private ?array $uniqueCities = null;
+    /** @var list<array{LocationId:int,Label:string,City:string,FederalCityId:?int}>|null */
+    private ?array $duplicateCities = null;
+    /** @var array<string,true>|null */
+    private ?array $duplicateCityNames = null;
+
+    /** Mirrors XmlManualOverRides.AlternateCityNames. Keys MUST be lowercase. */
+    private const ALTERNATE_CITY_NAMES = [
+        'one hundred mile house' => '100 Mile House',
+        'queen charlotte' => 'Daajing Giids ( Queen Charlotte City )',
+        'queen charlotte city' => 'Daajing Giids ( Queen Charlotte City )',
+        'cowichan valley a' => 'Lake Cowichan',
+        'cowichan' => 'Lake Cowichan',
+        'denny island' => 'Bella Bella',
+        'barrière' => 'Barriere',
+        'garden' => 'Garden Village',
+    ];
+
+    public function __construct(
+        private readonly PDO $db,
+        private readonly Logger $log,
+        private readonly int $wantedJobExpiryDays = 90,
+    ) {}
+
+    /**
+     * @return array<string,mixed>|null  null when the payload is empty, not JSON,
+     *         or has no usable id (the caller skips a null result).
+     */
+    public function convertToElasticJob(?string $jobData): ?array
+    {
+        if ($jobData === null || ltrim($jobData) === '') {
+            return null;
+        }
+        if (!str_starts_with(ltrim($jobData), '{')) {
+            // Innovibe payloads are always JSON; anything else is unexpected.
+            $this->log->warning('Non-JSON Wanted payload skipped');
+            return null;
+        }
+
+        try {
+            $j = json_decode($jobData, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            $this->log->error('Exception in convertToElasticJob() (decode): ' . $e->getMessage());
+            return null;
+        }
+        if (!is_array($j)) {
+            return null;
+        }
+
+        try {
+            return $this->buildDocument($j);
+        } catch (\Throwable $e) {
+            $this->log->error('Exception in convertToElasticJob(): ' . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $j
+     * @return array<string,mixed>|null
+     */
+    private function buildDocument(array $j): ?array
+    {
+        $jobId = (string) ($j['id'] ?? '');
+        if (trim($jobId) === '') {
+            // C# returns an empty ElasticSearchJob (JobId null) for these and the
+            // service skips a null JobId. Returning null is equivalent here.
+            return null;
+        }
+
+        $employmentTypes = is_array($j['employmentType'] ?? null) ? $j['employmentType'] : [];
+        $empTypeStr = strtolower(implode(' ', array_map('strval', $employmentTypes)));
+
+        // Dates
+        $postedDateStr = $j['postedDate'] ?? $j['createdAt'] ?? null;
+        $postedDate = $this->parseDateUtc($postedDateStr) ?? new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $updatedAtStr = $j['updatedAt'] ?? $postedDateStr;
+        $refreshedDate = $this->parseDateUtc($updatedAtStr) ?? $postedDate;
+
+        // Location: prefer a BC location
+        $city = '';
+        $province = '';
+        $lat = '';
+        $lon = '';
+        $locations = is_array($j['jobLocations'] ?? null) ? $j['jobLocations'] : [];
+        if (!empty($locations)) {
+            $loc = null;
+            foreach ($locations as $candidate) {
+                if (strcasecmp((string) ($candidate['state'] ?? ''), 'British Columbia') === 0) {
+                    $loc = $candidate;
+                    break;
+                }
+            }
+            $loc ??= $locations[0];
+            $city = (string) ($loc['city'] ?? '');
+            $province = (string) ($loc['state'] ?? $loc['province'] ?? '');
+            $lats = $loc['lats'] ?? null;
+            $lngs = $loc['lngs'] ?? null;
+            if (is_array($lats) && count($lats) > 0) {
+                $lat = $this->numberToString($lats[0]);
+            }
+            if (is_array($lngs) && count($lngs) > 0) {
+                $lon = $this->numberToString($lngs[0]);
+            }
+        }
+
+        if (trim($city) === '' && trim($province) !== '') {
+            $city = $province;
+        }
+        $city = $this->cleanUpCityName($city);
+
+        $co = is_array($j['company'] ?? null) ? $j['company'] : null;
+        $source = (string) ($j['sourceDomain'] ?? '');
+        $sourceUrl = (string) ($j['url'] ?? '');
+        $description = (string) ($j['description'] ?? '');
+        $employerName = (string) (($co['name'] ?? null) ?? $j['companyName'] ?? '');
+        $industry = (string) (($j['industry'] ?? null) ?? ($co['linkedinOrgIndustry'] ?? null) ?? '');
+        $function = (string) ($j['function'] ?? $j['category'] ?? '');
+        $title = (string) ($j['title'] ?? '');
+
+        $job = [
+            'JobId' => $jobId,
+            'DatePosted' => $this->formatNaive($refreshedDate),
+            'LastUpdated' => $this->formatNaive($refreshedDate),
+            'Lang' => 'en',
+            'SkillCategories' => [],
+            'City' => [$this->getJobCity($city)],
+            'Location' => [],
+            'Province' => trim($province),
+            'Region' => [$this->getJobRegion($city)],
+            'HoursOfWork' => ['Description' => []],
+            'PeriodOfEmployment' => ['Description' => []],
+            // EmploymentTerms.Description stays null for Wanted jobs, so Newtonsoft
+            // serializes the object as {} (an empty object, not []).
+            'EmploymentTerms' => new \stdClass(),
+            'IsFederalJob' => false,
+            'ExpireDate' => $this->formatNaive($refreshedDate->add(new \DateInterval('P' . $this->wantedJobExpiryDays . 'D'))),
+            'Industry' => $industry,
+            'JobDescription' => $description,
+            'Occupation' => '',
+            'Function' => $function,
+            // Federal-only value-type fields. The shared C# ElasticSearchJob class
+            // leaves these at their defaults for Wanted jobs, and Newtonsoft emits
+            // them (NullValueHandling.Ignore does not drop 0 / false).
+            'WorkHours' => 0.0,
+            'EmployerTypeId' => 0,
+            'IsVariousLocation' => false,
+            'IsAboriginal' => false,
+            'IsApprentice' => false,
+            'IsStudent' => false,
+            'IsNewcomer' => false,
+            'IsVeteran' => false,
+            'IsVismin' => false,
+            'IsYouth' => false,
+            'IsMatureWorker' => false,
+            'IsDisability' => false,
+        ];
+
+        // ── Employer name (must contain an English-ish word) ──────────
+        $job['EmployerName'] = $this->filterEmployerName($employerName);
+
+        // ── Salary ────────────────────────────────────────────────────
+        $salaryMin = $this->parseDecimal($j['salaryMin'] ?? null);
+        $salaryMax = $this->parseDecimal($j['salaryMax'] ?? null);
+        $salaryValue = $this->parseDecimal($j['salaryValue'] ?? null);
+        $salaryUnit = strtoupper((string) ($j['salaryUnitText'] ?? ''));
+        $salary = $salaryMin ?? $salaryValue ?? $salaryMax;
+
+        if ($salary !== null && $salary >= 0.01) {
+            $multiplier = match ($salaryUnit) {
+                'HOUR' => 2080.0,
+                'WEEK' => 52.0,
+                'MONTH' => 12.0,
+                default => 1.0,
+            };
+            // C# computes salary in `decimal` (exact). Innovibe salary fields
+            // carry up to 4 decimal places and the multiplier is an integer, so
+            // the true annual value has at most 4 decimals. Rounding there
+            // reproduces the decimal output while removing PHP float noise
+            // (e.g. 84275.15199999999 → 84275.152).
+            $annualSalary = $salary * $multiplier;
+            $job['Salary'] = round($annualSalary, 4);
+
+            if ($salaryMin !== null && $salaryMax !== null && $salaryMin != $salaryMax) {
+                $annualMin = $salaryMin * $multiplier;
+                $annualMax = $salaryMax * $multiplier;
+                $job['SalarySummary'] = '$' . number_format($annualMin) . ' - $' . number_format($annualMax) . ' annually';
+            } else {
+                $job['SalarySummary'] = '$' . number_format($annualSalary) . ' annually';
+            }
+        } else {
+            $job['Salary'] = null;
+            $job['SalarySummary'] = 'N/A';
+        }
+
+        // ── Hours of work ─────────────────────────────────────────────
+        $hours = [];
+        if (str_contains($empTypeStr, 'full')) {
+            $hours[] = 'Full-time';
+        }
+        if (str_contains($empTypeStr, 'part')) {
+            $hours[] = 'Part-time';
+        }
+        if (str_contains($empTypeStr, 'casual')) {
+            $hours[] = 'Casual';
+        }
+        if (str_contains($empTypeStr, 'on-call') || str_contains($empTypeStr, 'on_call')) {
+            $hours[] = 'On-call';
+        }
+        $job['HoursOfWork'] = ['Description' => $hours];
+
+        // ── Period of employment ──────────────────────────────────────
+        $period = [];
+        if (str_contains($empTypeStr, 'contract')) {
+            $period[] = 'Contract';
+        }
+        if (str_contains($empTypeStr, 'temporary') || str_contains($empTypeStr, 'freelance')) {
+            $period[] = 'Temporary';
+        }
+        if (str_contains($empTypeStr, 'seasonal')) {
+            $period[] = 'Seasonal';
+        }
+        if (str_contains($empTypeStr, 'intern')) {
+            $period[] = 'Intern';
+        }
+        if (str_contains($empTypeStr, 'student')) {
+            $period[] = 'Student';
+        }
+        $job['PeriodOfEmployment'] = ['Description' => $period];
+
+        // ── Location geo ──────────────────────────────────────────────
+        if ($lat !== '' && $lon !== '') {
+            $location = $this->locationOrNull($lat, $lon);
+            if ($location !== null) {
+                if (str_starts_with($location['Lat'], '999') && str_starts_with($location['Lon'], '999')) {
+                    $location = ['Lat' => self::SENTINEL_LAT, 'Lon' => self::SENTINEL_LON];
+                }
+                $job['Location'] = [$location];
+                $job['LocationGeo'] = [$location['Lat'] . ',' . $location['Lon']];
+            }
+        }
+
+        // ── Education (3 fallback strategies) ──────────────────────────
+        $eduLevel = null;
+        $educationLevel = (string) ($j['educationLevel'] ?? '');
+        if ($educationLevel !== '') {
+            $eduLevel = $this->mapEducationLevelText($educationLevel);
+        }
+        if (($eduLevel === null || $eduLevel === '')
+            && is_array($j['educationRequirementsDetailed'] ?? null)
+            && count($j['educationRequirementsDetailed']) > 0
+        ) {
+            $first = $j['educationRequirementsDetailed'][0];
+            $categoryName = (string) ($first['categoryName'] ?? '');
+            if ($categoryName !== '') {
+                $mapped = $this->mapEducationCategoryName($categoryName);
+                if ($mapped !== null && $mapped !== '') {
+                    $eduLevel = $mapped;
+                }
+            }
+            if (($eduLevel === null || $eduLevel === '')) {
+                $name = (string) ($first['name'] ?? '');
+                if ($name !== '') {
+                    $eduLevel = $this->mapEducationLevelText($name);
+                }
+            }
+        }
+        if (($eduLevel === null || $eduLevel === '')
+            && is_array($j['educationRequirements'] ?? null)
+            && count($j['educationRequirements']) > 0
+        ) {
+            $firstReq = (string) ($j['educationRequirements'][0] ?? '');
+            if ($firstReq !== '') {
+                $eduLevel = $this->mapEducationLevelText($firstReq);
+            }
+        }
+        if ($eduLevel !== null && $eduLevel !== '') {
+            $job['EduLevel'] = $eduLevel;
+        }
+
+        // ── Apply fields ──────────────────────────────────────────────
+        $job['ApplyEmailAddress'] = '';
+        $job['ApplyPhoneNumber'] = '';
+        $job['ApplyWebsite'] = $sourceUrl;
+        $job['PositionsAvailable'] = 1;
+        $job['NaicsId'] = null;
+
+        // ── NOC 2021 (from highest-scored nocMatches) ─────────────────
+        $nocStr = '';
+        $nocLabel = '';
+        $nocMatches = is_array($j['nocMatches'] ?? null) ? $j['nocMatches'] : [];
+        if (count($nocMatches) > 0) {
+            $best = $nocMatches[0];
+            $bestScore = (float) ($best['score'] ?? 0);
+            foreach ($nocMatches as $m) {
+                $s = (float) ($m['score'] ?? 0);
+                if ($s > $bestScore) {
+                    $best = $m;
+                    $bestScore = $s;
+                }
+            }
+            $nocStr = (string) ($best['code'] ?? '');
+            $nocLabel = (string) ($best['title'] ?? '');
+        }
+
+        $noc2021Int = 0;
+        if ($nocStr !== '') {
+            $noc2021Int = (int) $nocStr;
+            if (!$this->isValidNoc2021($noc2021Int)) {
+                $noc2021Int = 0;
+            }
+        }
+        $job['Noc2021'] = $noc2021Int === 0 ? null : $noc2021Int;
+
+        if ($noc2021Int > 0) {
+            $job['NocGroup'] = $this->getNocGroup2021($noc2021Int);
+            $job['NocJobTitle'] = str_replace("\u{200B}", '', $nocLabel);
+        }
+
+        // Legacy Noc (2016) intentionally left null for Innovibe jobs.
+        $job['Noc'] = null;
+
+        if ($nocLabel !== '') {
+            $job['Occupation'] = $nocLabel;
+        }
+
+        // ── Job title cleanup ─────────────────────────────────────────
+        // C# uses String.Trim() which strips all Unicode whitespace (incl. the
+        // NBSP that some feed titles carry); PHP trim() only handles ASCII.
+        if ($this->unicodeTrim($title) !== '') {
+            $job['Title'] = str_replace("\u{200B}", '', $this->unicodeTrim($title));
+        }
+        $job['Title'] = $this->cleanTitle($job['Title'] ?? null, $job['NocJobTitle'] ?? null);
+
+        // ── External source ───────────────────────────────────────────
+        $sources = [];
+        if ($source !== '' || $sourceUrl !== '') {
+            $sources[] = ['Url' => $sourceUrl, 'Source' => $source];
+        }
+        $job['ExternalSource'] = ['Source' => $sources];
+
+        $job['SalarySort'] = $this->salarySort($job['Salary'] ?? null, $job['SalarySummary'] ?? null);
+
+        return $job;
+    }
+
+    // ── Title cleanup ──────────────────────────────────────────────
+
+    private function cleanTitle(?string $title, ?string $nocJobTitle): string
+    {
+        $title ??= '';
+        // substitute NocJobTitle if Title has no letters
+        if (preg_match('/[a-zA-Z]/', $title) !== 1) {
+            $title = ($nocJobTitle === null || $nocJobTitle === '')
+                ? 'No job title provided'
+                : $nocJobTitle;
+        }
+        // all-caps → lowercase (CSS title-cases via text-transform)
+        if (!preg_match('/\p{Ll}/u', $title)) {
+            $title = mb_strtolower($title);
+        }
+        // always capitalize PT / FT
+        $title = preg_replace('/\bpt\b/i', 'PT', $title) ?? $title;
+        $title = preg_replace('/\bft\b/i', 'FT', $title) ?? $title;
+        return $title;
+    }
+
+    private function filterEmployerName(string $employerName): string
+    {
+        $employerName = trim($employerName);
+        if ($employerName === '') {
+            return '';
+        }
+        // Mirrors the C# regex new Regex("[a-zA-Z0-9$@!%*?&#^_.+-]+").
+        return preg_match('/[a-zA-Z0-9$@!%*?&#^_.+\-]+/', $employerName) === 1 ? $employerName : '';
+    }
+
+    // ── Education maps ─────────────────────────────────────────────
+
+    private function mapEducationLevelText(string $text): ?string
+    {
+        $t = strtolower(trim($text));
+        return match ($t) {
+            'less than high school', 'no education' => 'No education',
+            "some college", "associate's degree", 'postsecondary', 'college', 'apprenticeship' => 'College or apprenticeship',
+            'doctoral', "master's degree", "bachelor's degree", 'university' => 'University',
+            'high school', 'high school diploma', 'high school diploma or equivalent' => 'Secondary school or job-specific training',
+            default => null,
+        };
+    }
+
+    private function mapEducationCategoryName(string $categoryName): ?string
+    {
+        $c = strtolower(trim($categoryName));
+        return match ($c) {
+            'no education' => 'No education',
+            'college', 'college or apprenticeship', 'apprenticeship' => 'College or apprenticeship',
+            'university' => 'University',
+            'secondary school or job-specific training', 'secondary school', 'high school' => 'Secondary school or job-specific training',
+            default => null,
+        };
+    }
+
+    // ── Location ───────────────────────────────────────────────────
+
+    /**
+     * @return array{Lat:string,Lon:string}|null
+     */
+    private function locationOrNull(string $lat, string $lon): ?array
+    {
+        if (!is_numeric($lat) || !is_numeric($lon)) {
+            return null;
+        }
+        $dLat = (float) $lat;
+        $dLon = (float) $lon;
+        if ($dLat > 48.2 && $dLat < 60 && $dLon < -114 && $dLon > -139) {
+            return ['Lat' => $lat, 'Lon' => $lon];
+        }
+        return null;
+    }
+
+    // ── City / region disambiguation (XmlParsingServiceBase) ───────
+
+    private function cleanUpCityName(string $cityName): string
+    {
+        if (str_contains($cityName, '&apos;')) {
+            $cityName = str_replace('&apos;', "'", $cityName);
+        }
+        $key = mb_strtolower($cityName);
+        return self::ALTERNATE_CITY_NAMES[$key] ?? $cityName;
+    }
+
+    private function getJobCity(string $cityName, int $cityId = 0): string
+    {
+        $this->loadDuplicateCities();
+        $lower = mb_strtolower($cityName);
+        if (!isset($this->duplicateCityNames[$lower])) {
+            return $cityName;
+        }
+
+        if ($cityId !== 0) {
+            foreach ($this->duplicateCities as $row) {
+                if ($row['FederalCityId'] === $cityId) {
+                    return $row['Label'];
+                }
+            }
+        } else {
+            foreach ($this->duplicateCities as $row) {
+                if (mb_strtolower($row['City']) === $lower) {
+                    return $row['Label'];
+                }
+            }
+        }
+
+        foreach ($this->duplicateCities as $row) {
+            if (mb_strtolower($row['City']) === $lower && $row['FederalCityId'] === null) {
+                return $row['Label'];
+            }
+        }
+
+        return $cityName;
+    }
+
+    private function getJobRegion(string $cityName, int $cityId = 0): string
+    {
+        $this->loadUniqueCities();
+        $this->loadDuplicateCities();
+        $lower = mb_strtolower($cityName);
+
+        if (isset($this->uniqueCities[$lower])) {
+            return $this->uniqueCities[$lower];
+        }
+
+        if ($cityId !== 0) {
+            foreach ($this->duplicateCities as $row) {
+                if ($row['FederalCityId'] === $cityId) {
+                    return $this->stripCityFromLabel($row['Label'], $row['City']);
+                }
+            }
+        }
+
+        foreach ($this->duplicateCities as $row) {
+            if (mb_strtolower($row['City']) === $lower) {
+                return $this->stripCityFromLabel($row['Label'], $row['City']);
+            }
+        }
+
+        return '';
+    }
+
+    private function stripCityFromLabel(string $label, string $city): string
+    {
+        $needle = $city . ' - ';
+        $pos = strpos($label, $needle);
+        if ($pos === false) {
+            return $label;
+        }
+        return substr_replace($label, '', $pos, strlen($needle));
+    }
+
+    // ── NOC ────────────────────────────────────────────────────────
+
+    private function getNocGroup2021(?int $nocId, bool $isFrench = false): string
+    {
+        if ($nocId === null || $nocId === 0) {
+            return '';
+        }
+        $this->loadNocGroups2021();
+        $codeStr = str_pad((string) $nocId, 5, '0', STR_PAD_LEFT);
+        if (!isset($this->nocGroups2021[$nocId])) {
+            return $codeStr;
+        }
+        $group = $this->nocGroups2021[$nocId];
+        $title = $isFrench ? $group['frenchTitle'] : $group['title'];
+        if ($title !== null && $title !== '') {
+            return "{$title} ({$codeStr})";
+        }
+        return $codeStr;
+    }
+
+    // ── Salary sort ────────────────────────────────────────────────
+
+    /**
+     * @return array{Ascending:float,Descending:float}
+     */
+    private function salarySort(?float $salary, ?string $salarySummary): array
+    {
+        if ($salarySummary === 'N/A') {
+            return ['Ascending' => 99999999.0, 'Descending' => -99999999.0];
+        }
+        $isZero = ($salary ?? 0.0) < 0.01;
+        return [
+            'Ascending' => $isZero ? 88888888.0 : $salary,
+            'Descending' => $isZero ? -88888888.0 : $salary,
+        ];
+    }
+
+    // ── DB lookups (lazy, cached) ──────────────────────────────────
+
+    private function isValidNoc2021(int $id): bool
+    {
+        $this->loadNocGroups2021();
+        return isset($this->nocGroups2021[$id]);
+    }
+
+    private function loadNocGroups2021(): void
+    {
+        if ($this->nocGroups2021 !== null) {
+            return;
+        }
+        $rows = $this->db->query('SELECT "Id","Title","FrenchTitle" FROM "NocCodes2021"')?->fetchAll() ?: [];
+        $this->nocGroups2021 = [];
+        foreach ($rows as $row) {
+            $this->nocGroups2021[(int) $row['Id']] = [
+                'title' => $row['Title'] !== null ? (string) $row['Title'] : null,
+                'frenchTitle' => $row['FrenchTitle'] !== null ? (string) $row['FrenchTitle'] : null,
+            ];
+        }
+        $this->log->info(count($this->nocGroups2021) . ' NOC 2021 codes loaded');
+    }
+
+    private function loadUniqueCities(): void
+    {
+        if ($this->uniqueCities !== null) {
+            return;
+        }
+        $rows = $this->db->query('
+            SELECT l."City", r."Name" AS "Region"
+            FROM "Locations" l
+            INNER JOIN "Regions" r ON r."Id" = l."RegionId"
+            WHERE l."IsDuplicate" = FALSE
+              AND l."IsHidden" = FALSE
+              AND l."RegionId" IS NOT NULL
+              AND (r."Id" = 0 OR r."IsHidden" = FALSE)
+        ')?->fetchAll() ?: [];
+
+        $this->uniqueCities = [];
+        foreach ($rows as $row) {
+            $city = trim((string) ($row['City'] ?? ''));
+            if ($city === '') {
+                continue;
+            }
+            $this->uniqueCities[mb_strtolower($city)] = (string) ($row['Region'] ?? '');
+        }
+        $this->log->info(count($this->uniqueCities) . ' unique cities loaded for region lookup');
+    }
+
+    private function loadDuplicateCities(): void
+    {
+        if ($this->duplicateCities !== null) {
+            return;
+        }
+        $rows = $this->db->query('
+            SELECT "LocationId", "Label", "City", "FederalCityId"
+            FROM "Locations"
+            WHERE "IsDuplicate" = TRUE AND "IsHidden" = FALSE
+        ')?->fetchAll() ?: [];
+
+        $this->duplicateCities = [];
+        $this->duplicateCityNames = [];
+        foreach ($rows as $row) {
+            $cityName = trim((string) ($row['City'] ?? ''));
+            $this->duplicateCities[] = [
+                'LocationId' => (int) $row['LocationId'],
+                'Label' => trim((string) ($row['Label'] ?? '')),
+                'City' => $cityName,
+                'FederalCityId' => $row['FederalCityId'] === null ? null : (int) $row['FederalCityId'],
+            ];
+            if ($cityName !== '') {
+                $this->duplicateCityNames[mb_strtolower($cityName)] = true;
+            }
+        }
+        $this->log->info(count($this->duplicateCities) . ' duplicate cities loaded for disambiguation');
+    }
+
+    // ── parsing helpers ────────────────────────────────────────────
+
+    private function parseDateUtc(mixed $raw): ?\DateTimeImmutable
+    {
+        if ($raw === null) {
+            return null;
+        }
+        $raw = (string) $raw;
+        if (trim($raw) === '') {
+            return null;
+        }
+        try {
+            return new \DateTimeImmutable($raw, new \DateTimeZone('UTC'));
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Formats as a naive ISO 8601 timestamp WITHOUT an offset, e.g.
+     * "2026-04-27T03:11:06". The .NET Wanted indexer's dates come from
+     * Convert.ToDateTime(jsonString) with DateTimeKind.Unspecified, which
+     * Newtonsoft serializes without a "Z" or offset. We keep the same wall-clock
+     * instant (parsed as UTC) and drop the offset to match byte-for-byte.
+     */
+    private function formatNaive(\DateTimeImmutable $dt): string
+    {
+        return $dt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s');
+    }
+
+    private function parseDecimal(mixed $raw): ?float
+    {
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        if (is_int($raw) || is_float($raw)) {
+            return (float) $raw;
+        }
+        $clean = str_replace([',', ' '], '', (string) $raw);
+        return is_numeric($clean) ? (float) $clean : null;
+    }
+
+    /**
+     * Strips ALL Unicode whitespace including U+00A0 (NBSP) to match C#
+     * String.Trim(). PHP trim() only handles ASCII whitespace.
+     */
+    private function unicodeTrim(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+        return preg_replace('/^[\pZ\pC]+|[\pZ\pC]+$/u', '', $value) ?? $value;
+    }
+
+    /**
+     * Stringifies a JSON-decoded number the way .NET's JToken.ToString() does:
+     * the shortest round-trippable representation. PHP's (string) cast uses the
+     * `precision` ini (14) and would drop digits (49.26403579999999 →
+     * 49.2640358); json_encode honours `serialize_precision = -1` and produces
+     * the exact round-trip form, matching the .NET output.
+     */
+    private function numberToString(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return json_encode($value);
+        }
+        return (string) $value;
+    }
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/src/Service/IndexMaintenanceService.php
+++ b/src/WorkBC.Indexers.Innovibe.V2/src/Service/IndexMaintenanceService.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkBC\InnovibeJobIndexer\Service;
+
+use Monolog\Logger;
+use PDO;
+use WorkBC\InnovibeJobIndexer\Config\AppConfig;
+use WorkBC\InnovibeJobIndexer\Elastic\ElasticClient;
+
+/**
+ * Index-level maintenance: recreate indexes (--reindex) and close/reopen them
+ * to reload synonyms (--reopen).
+ *
+ * Ports WorkBC.ElasticSearch.Indexing.Services.ReIndexingService.
+ */
+final class IndexMaintenanceService
+{
+    public function __construct(
+        private readonly PDO $db,
+        private readonly ElasticClient $elastic,
+        private readonly AppConfig $config,
+        private readonly Logger $log,
+    ) {}
+
+    /** @return list<string> */
+    private function indexes(): array
+    {
+        return [$this->config->indexEn, $this->config->indexFr];
+    }
+
+    /**
+     * Drop both indexes, recreate them from jobs_index.json.template, and flag every
+     * staging row (Wanted + Federal) for re-indexing.
+     */
+    public function reCreateIndex(): void
+    {
+        $indexes = $this->indexes();
+
+        $this->log->info('Removing index(es) ' . implode(',', $indexes));
+        foreach ($indexes as $index) {
+            $this->elastic->deleteIndex($index);
+        }
+
+        $this->log->info('Creating index(es) ' . implode(',', $indexes));
+        foreach ($indexes as $index) {
+            // The .NET ReIndexingService calls CreateIndexService.Create(false),
+            // i.e. it uses the inline (predefined) synonyms rather than the
+            // synonyms_path file. We match that so a reindex does not depend on
+            // a synonym.txt being present on the ES node.
+            if ($this->elastic->createIndex($index, false)) {
+                $this->log->info("Index created - {$index}");
+            } else {
+                $this->log->error("Index NOT created - {$index}");
+            }
+        }
+
+        $this->log->info('Updating jobs to re-index...');
+        $this->flagAllJobsForReIndexing();
+        $this->log->info('Done. Indexing will continue with the new index');
+    }
+
+    /** Close then reopen both indexes (reloads the synonym file). */
+    public function reCloseAndReOpenIndexes(): void
+    {
+        foreach ($this->indexes() as $index) {
+            $this->elastic->closeAndReopen($index);
+        }
+    }
+
+    /**
+     * Flags ALL rows in both staging tables. Mirrors the C#
+     * ReIndexingService.FlagAllJobsForReIndexing (which deliberately touches
+     * both Wanted and Federal so a shared reindex covers every source).
+     */
+    private function flagAllJobsForReIndexing(): void
+    {
+        $this->db->exec('UPDATE "ImportedJobsWanted" SET "ReIndexNeeded" = TRUE');
+        $this->db->exec('UPDATE "ImportedJobsFederal" SET "ReIndexNeeded" = TRUE');
+    }
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/src/Service/InnovibeIndexService.php
+++ b/src/WorkBC.Indexers.Innovibe.V2/src/Service/InnovibeIndexService.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkBC\InnovibeJobIndexer\Service;
+
+use Monolog\Logger;
+use PDO;
+use WorkBC\InnovibeJobIndexer\Config\AppConfig;
+use WorkBC\InnovibeJobIndexer\Elastic\ElasticClient;
+use WorkBC\InnovibeJobIndexer\Json\InnovibeDocumentMapper;
+
+/**
+ * Innovibe (Wanted) indexer orchestrator. Reads ImportedJobsWanted rows flagged
+ * for re-indexing (non-federal only), builds the Elasticsearch document, PUTs it
+ * into jobs_en, clears the flag, then purges expired and orphaned docs.
+ *
+ * Faithful port of WorkBC.Indexers.Wanted.Services.WantedIndexService. Unlike the
+ * federal indexer there is a single index and a data-quality gate: jobs missing
+ * the fields the UI search relies on are parked in ExpiredJobs + flipped inactive
+ * in Jobs instead of being indexed.
+ */
+final class InnovibeIndexService
+{
+    private const FLUSH_THRESHOLD = 100;
+    private const PURGE_BATCH = 100;
+    private const JOB_SOURCE_WANTED = 2;
+
+    /** @var list<string> JobIds whose ReIndexNeeded flag is pending clear */
+    private array $pendingIds = [];
+    /** @var list<string> JobIds rejected by the publishable gate, pending FlushRejected */
+    private array $rejectedIds = [];
+
+    public function __construct(
+        private readonly PDO $db,
+        private readonly ElasticClient $elastic,
+        private readonly InnovibeDocumentMapper $mapper,
+        private readonly AppConfig $config,
+        private readonly Logger $log,
+    ) {}
+
+    // ── Index ──────────────────────────────────────────────────────
+
+    public function indexJobs(): void
+    {
+        $rows = $this->db->query('
+            SELECT "JobId", "JobPostEnglish"
+            FROM "ImportedJobsWanted"
+            WHERE "ReIndexNeeded" = TRUE AND "IsFederalOrWorkBc" = FALSE
+        ')->fetchAll();
+
+        $this->log->info(count($rows) . ' wanted jobs to index');
+
+        $processed = 0;
+        $indexed = 0;
+        $rejected = 0;
+        foreach ($rows as $row) {
+            $jobId = (string) $row['JobId'];
+            $doc = $this->mapper->convertToElasticJob($row['JobPostEnglish']);
+
+            // A null document (or one without a JobId) is a job from the feds /
+            // WorkBC; just clear its flag (mirrors the C# else-branch).
+            if ($doc === null || ($doc['JobId'] ?? null) === null) {
+                $this->pendingIds[] = $jobId;
+                $this->maybeFlush();
+                $processed++;
+                continue;
+            }
+
+            // Data-quality gate: unpublishable rows are parked, not indexed.
+            if (!$this->isPublishable($doc)) {
+                $this->rejectedIds[] = $doc['JobId'];
+                $this->pendingIds[] = $doc['JobId'];
+                $rejected++;
+                $this->maybeFlush();
+                $processed++;
+                continue;
+            }
+
+            $json = $this->serialize($doc);
+            $result = $this->putWithRetry($doc['JobId'], $json);
+
+            if ($result === 'error') {
+                // Problem with Elasticsearch — most likely down. Stop here so we
+                // don't churn the whole batch (mirrors the C# CRITICAL ERROR break).
+                $this->log->error('CRITICAL ERROR talking to Elasticsearch — stopping index loop');
+                break;
+            }
+
+            if ($result === 'ok' || $result === 'created' || $result === 'updated') {
+                $this->pendingIds[] = $jobId;
+                $indexed++;
+            }
+
+            $this->maybeFlush();
+            $processed++;
+            if ($processed % 1000 === 0) {
+                $this->log->info("Processed {$processed} jobs...");
+            }
+        }
+
+        $this->updateIds();
+        $this->flushRejected();
+        $this->log->info("Indexing complete — processed={$processed} indexed={$indexed} rejected={$rejected}");
+    }
+
+    private function maybeFlush(): void
+    {
+        if (count($this->rejectedIds) >= self::FLUSH_THRESHOLD) {
+            $this->flushRejected();
+        }
+        if (count($this->pendingIds) > self::FLUSH_THRESHOLD) {
+            $this->updateIds();
+        }
+    }
+
+    /**
+     * Data-quality gate. Mirrors WantedIndexService.IsPublishable: a job must
+     * have a Title, an EmployerName, a valid Noc2021, and a non-empty City[0].
+     *
+     * @param array<string,mixed> $doc
+     */
+    private function isPublishable(array $doc): bool
+    {
+        if (trim((string) ($doc['Title'] ?? '')) === '') {
+            return false;
+        }
+        if (trim((string) ($doc['EmployerName'] ?? '')) === '') {
+            return false;
+        }
+        $noc = $doc['Noc2021'] ?? null;
+        if ($noc === null || (int) $noc === 0) {
+            return false;
+        }
+        $city = $doc['City'] ?? null;
+        if (!is_array($city) || count($city) === 0 || trim((string) ($city[0] ?? '')) === '') {
+            return false;
+        }
+        return true;
+    }
+
+    private function putWithRetry(string $jobId, ?string $json): string
+    {
+        if ($json === null || $json === 'null') {
+            return 'error';
+        }
+        $result = $this->elastic->putDocument($this->config->indexEn, $jobId, $json);
+        if ($result === 'error') {
+            if ($this->config->retryDelayMs > 0) {
+                usleep($this->config->retryDelayMs * 1000);
+            }
+            $result = $this->elastic->putDocument($this->config->indexEn, $jobId, $json);
+        }
+        return $result;
+    }
+
+    /**
+     * Clear ReIndexNeeded for the buffered JobIds. The Wanted indexer correctly
+     * targets ImportedJobsWanted (the table it reads), unlike the federal indexer.
+     */
+    private function updateIds(): void
+    {
+        if (empty($this->pendingIds)) {
+            return;
+        }
+        try {
+            $placeholders = implode(',', array_fill(0, count($this->pendingIds), '?'));
+            $stmt = $this->db->prepare(
+                "UPDATE \"ImportedJobsWanted\" SET \"ReIndexNeeded\" = FALSE WHERE \"JobId\" IN ({$placeholders})"
+            );
+            $stmt->execute(array_values($this->pendingIds));
+        } catch (\Throwable $e) {
+            $this->log->error('ERROR: Could not update SQL column `ReIndexNeeded`. Reason: ' . $e->getMessage());
+        }
+        $this->pendingIds = [];
+    }
+
+    /**
+     * Park rejected jobs: upsert into ExpiredJobs and flip Jobs.IsActive = FALSE
+     * so admin counts stop tracking them. Mirrors WantedIndexService.FlushRejected.
+     */
+    private function flushRejected(): void
+    {
+        if (empty($this->rejectedIds)) {
+            return;
+        }
+        try {
+            $placeholders = implode(',', array_fill(0, count($this->rejectedIds), '?'));
+            $ids = array_values($this->rejectedIds);
+
+            $expire = $this->db->prepare(
+                "INSERT INTO \"ExpiredJobs\" (\"JobId\", \"DateRemoved\", \"RemovedFromElasticsearch\")
+                 SELECT v, NOW(), FALSE FROM (SELECT unnest(ARRAY[{$placeholders}]::varchar[]) AS v) s
+                 ON CONFLICT (\"JobId\") DO UPDATE
+                 SET \"DateRemoved\" = NOW(), \"RemovedFromElasticsearch\" = FALSE"
+            );
+            $expire->execute($ids);
+
+            $deactivate = $this->db->prepare(
+                "UPDATE \"Jobs\" SET \"IsActive\" = FALSE, \"LastUpdated\" = NOW()
+                 WHERE \"JobId\" IN ({$placeholders}) AND \"IsActive\" = TRUE"
+            );
+            $deactivate->execute($ids);
+
+            $this->rejectedIds = [];
+        } catch (\Throwable $e) {
+            $this->log->error('ERROR: Could not write rejected jobs to ExpiredJobs/Jobs. Reason: ' . $e->getMessage());
+        }
+    }
+
+    // ── Purge ──────────────────────────────────────────────────────
+
+    public function purgeJobs(): void
+    {
+        $expired = $this->db->query('
+            SELECT "JobId" FROM "ExpiredJobs" WHERE "RemovedFromElasticsearch" = FALSE
+        ')->fetchAll(PDO::FETCH_COLUMN);
+
+        $markRemoved = $this->db->prepare(
+            'UPDATE "ExpiredJobs" SET "RemovedFromElasticsearch" = TRUE WHERE "JobId" = ?'
+        );
+
+        $counter = 0;
+        foreach ($expired as $jobId) {
+            $jobId = (string) $jobId;
+            $this->elastic->deleteDocument($this->config->indexEn, $jobId);
+            $markRemoved->execute([$jobId]);
+            $counter++;
+            if ($counter % self::PURGE_BATCH === 0) {
+                $this->log->info("Purged {$counter} expired jobs...");
+            }
+        }
+
+        // Sweep orphans: non-federal docs in ES whose JobId is no longer in staging.
+        $stagingIds = $this->db->query('
+            SELECT "JobId" FROM "ImportedJobsWanted" WHERE "IsFederalOrWorkBc" = FALSE
+        ')->fetchAll(PDO::FETCH_COLUMN);
+        $stagingLookup = array_flip(array_map('strval', $stagingIds));
+
+        $orphans = 0;
+        foreach ($this->elastic->getJobIdsBySource($this->config->indexEn, false) as $jobId) {
+            if (!isset($stagingLookup[$jobId])) {
+                $this->elastic->deleteDocument($this->config->indexEn, $jobId);
+                $orphans++;
+            }
+        }
+
+        $this->log->info("Purge complete — expired={$counter} orphans={$orphans}");
+    }
+
+    // ── Debug ──────────────────────────────────────────────────────
+
+    public function debug(): void
+    {
+        $elasticIds = $this->elastic->getJobIdsBySource($this->config->indexEn, false, true);
+
+        $sqlIds = $this->db->query('
+            SELECT "JobId" FROM "Jobs"
+            WHERE "JobSourceId" = ' . self::JOB_SOURCE_WANTED . '
+              AND "ExpireDate" > NOW()
+              AND "IsActive" = TRUE
+        ')->fetchAll(PDO::FETCH_COLUMN);
+        $sqlIds = array_map('strval', $sqlIds);
+
+        $elasticSet = array_flip($elasticIds);
+        $sqlSet = array_flip($sqlIds);
+
+        echo 'Active jobs found in Elasticsearch: ' . count($elasticIds) . PHP_EOL;
+        echo 'Active jobs found in the Jobs table: ' . count($sqlIds) . PHP_EOL;
+        echo PHP_EOL;
+        echo 'JobIds found in Elasticsearch but not in the Jobs table:' . PHP_EOL;
+        foreach ($elasticIds as $id) {
+            if (!isset($sqlSet[$id])) {
+                echo $id . PHP_EOL;
+            }
+        }
+        echo PHP_EOL;
+        echo 'JobIds found in the Jobs table but not in Elasticsearch:' . PHP_EOL;
+        foreach ($sqlIds as $id) {
+            if (!isset($elasticSet[$id])) {
+                echo $id . PHP_EOL;
+            }
+        }
+    }
+
+    // ── Serialization ──────────────────────────────────────────────
+
+    private function serialize(?array $document): ?string
+    {
+        if ($document === null) {
+            return null;
+        }
+        return json_encode($this->stripNulls($document), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @param array<mixed> $value
+     * @return array<mixed>
+     */
+    private function stripNulls(array $value): array
+    {
+        $out = [];
+        foreach ($value as $key => $item) {
+            if ($item === null) {
+                continue;
+            }
+            // Objects (e.g. EmploymentTerms = stdClass for an empty {}) pass
+            // through untouched so json_encode keeps them as {} rather than [].
+            $out[$key] = is_array($item) ? $this->stripNulls($item) : $item;
+        }
+        return $out;
+    }
+}

--- a/src/WorkBC.Indexers.Innovibe.V2/src/index.php
+++ b/src/WorkBC.Indexers.Innovibe.V2/src/index.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use WorkBC\InnovibeJobIndexer\Config\AppConfig;
+use WorkBC\InnovibeJobIndexer\Elastic\ElasticClient;
+use WorkBC\InnovibeJobIndexer\Json\InnovibeDocumentMapper;
+use WorkBC\InnovibeJobIndexer\Service\IndexMaintenanceService;
+use WorkBC\InnovibeJobIndexer\Service\InnovibeIndexService;
+
+if (file_exists(__DIR__ . '/../.env')) {
+    Dotenv\Dotenv::createImmutable(__DIR__ . '/..')->safeLoad();
+}
+
+$config = new AppConfig();
+
+// ── CLI flags (mirror WorkBC.ElasticSearch.Indexing.CommandLineOptions) ──
+$reIndex = false;     // -r / --reindex : drop + recreate the indexes, flag all rows
+$reOpen = false;      // -o / --reopen  : close + reopen to reload synonyms
+$skipReIndex = false; // -n / --noreindex : skip the indexing loop
+$debug = false;       // -d / --debug   : print ES-vs-Jobs diff and exit
+
+foreach (array_slice($argv ?? [], 1) as $arg) {
+    switch ($arg) {
+        case '-r':
+        case '--reindex':
+            $reIndex = true;
+            break;
+        case '-o':
+        case '--reopen':
+            $reOpen = true;
+            break;
+        case '-n':
+        case '--noreindex':
+            $skipReIndex = true;
+            break;
+        case '-d':
+        case '--debug':
+            $debug = true;
+            break;
+    }
+}
+
+$logger = new Logger('innovibe-indexer');
+$handler = new StreamHandler('php://stdout', Level::fromName($config->logLevel));
+$handler->setFormatter(new LineFormatter("[%datetime%] %level_name%  %message%\n", 'H:i:s'));
+$logger->pushHandler($handler);
+
+try {
+    $pdo = new PDO($config->dbDsn, $config->dbUser, $config->dbPassword, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (Throwable $e) {
+    $logger->critical('Failed to connect to PostgreSQL: ' . $e->getMessage());
+    exit(1);
+}
+
+$elastic = new ElasticClient($config, $logger);
+$mapper = new InnovibeDocumentMapper($pdo, $logger, $config->wantedJobExpiryDays);
+$maintenance = new IndexMaintenanceService($pdo, $elastic, $config, $logger);
+$indexer = new InnovibeIndexService($pdo, $elastic, $mapper, $config, $logger);
+
+try {
+    if ($debug) {
+        $indexer->debug();
+        exit(0);
+    }
+
+    $logger->info('INDEXER STARTED');
+
+    // Maintenance first (recreate or close/reopen), mirroring MainTask().
+    if ($reIndex) {
+        $logger->info('Recreating the job indexes');
+        $maintenance->reCreateIndex();
+    }
+    if ($reOpen) {
+        $logger->info('Closing and reopening the job indexes to update synonyms');
+        $maintenance->reCloseAndReOpenIndexes();
+    }
+
+    // Index loop runs unless --noreindex was passed.
+    if (!$skipReIndex) {
+        $logger->info('Indexing jobs - start');
+        try {
+            $indexer->indexJobs();
+        } catch (Throwable $e) {
+            $logger->error($e->getMessage());
+            $logger->error('ERROR PROCESSING RECORDS... SKIPPING AHEAD TO THE NEXT TASK');
+        }
+        $logger->info('Indexing jobs - done.');
+    }
+
+    // Purge runs on every run that is NOT a fresh --reindex (matches the Wanted
+    // Program.cs: `if (!options.ReIndex) { PurgeJobs(); }`). Note it runs even
+    // with --noreindex, unlike the federal indexer.
+    if (!$reIndex) {
+        $logger->info('Purging expired jobs from Elasticsearch');
+        try {
+            $indexer->purgeJobs();
+        } catch (Throwable $e) {
+            $logger->error($e->getMessage());
+        }
+    }
+
+    $logger->info('INDEXER FINISHED');
+    exit(0);
+} catch (Throwable $e) {
+    $logger->error('INDEXER FAILED: ' . $e->getMessage());
+    $logger->error($e->getTraceAsString());
+    exit(2);
+}

--- a/src/docker-compose.linux-dev.yml
+++ b/src/docker-compose.linux-dev.yml
@@ -40,6 +40,12 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+  indexers-innovibe-v2:
+    depends_on:
+      postgres:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
   indexers-wanted:
     volumes:
       - ./WorkBC.Indexers.Wanted/appsettings.linux.json:/app/appsettings.json

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -85,6 +85,18 @@ services:
             - DB_HOST=postgres
             - DB_NAME=jobboard
             - ELASTIC_URL=http://elasticsearch:9200
+    indexers-innovibe-v2:
+        container_name: indexers-innovibe-v2
+        scale: 0
+        build:
+            context: ./WorkBC.Indexers.Innovibe.V2
+            dockerfile: Dockerfile
+        env_file:
+            - .env
+        environment:
+            - DB_HOST=postgres
+            - DB_NAME=jobboard
+            - ELASTIC_URL=http://elasticsearch:9200
     indexers-wanted:
         container_name: indexers-wanted
         scale: 0

--- a/src/php-cli.Dockerfile
+++ b/src/php-cli.Dockerfile
@@ -26,6 +26,16 @@ RUN composer install --no-dev --no-interaction --optimize-autoloader --prefer-di
 COPY WorkBC.Indexers.Federal.V2/src/ src/
 COPY WorkBC.Indexers.Federal.V2/resources/ resources/
 
+FROM php:8.3-cli-alpine AS innovibe-indexer-app
+RUN apk add --no-cache postgresql-dev libxml2-dev autoconf gcc g++ make unzip \
+    && docker-php-ext-install pdo_pgsql dom simplexml
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+WORKDIR /app
+COPY WorkBC.Indexers.Innovibe.V2/composer.json ./
+RUN composer install --no-dev --no-interaction --optimize-autoloader --prefer-dist
+COPY WorkBC.Indexers.Innovibe.V2/src/ src/
+COPY WorkBC.Indexers.Innovibe.V2/resources/ resources/
+
 FROM php:8.3-cli-alpine
 RUN apk add --no-cache bash postgresql-client postgresql-libs libxml2 tzdata \
     && apk add --no-cache --virtual .bd postgresql-dev libxml2-dev autoconf gcc g++ make \
@@ -38,6 +48,7 @@ RUN apk add --no-cache bash postgresql-client postgresql-libs libxml2 tzdata \
 COPY --from=federal-app          /app /app/workbc-importers-federal-v2
 COPY --from=innovibe-app         /app /app/workbc-importers-innovibe
 COPY --from=federal-indexer-app  /app /app/workbc-indexers-federal-v2
+COPY --from=innovibe-indexer-app /app /app/workbc-indexers-innovibe-v2
 
 COPY WorkBC.Importers.Federal.V2/php.ini /usr/local/etc/php/conf.d/php.ini
 
@@ -45,7 +56,7 @@ RUN cat > /root/.bashrc <<'EOF'
 cat <<'B'
 ─────────────────────────────────────────────────────────────────────
   WorkBC PHP CLI  ·  PHP 8.3
-  Federal V2 + Innovibe importers + Federal indexer in one shell.
+  Federal V2 + Innovibe importers + Federal & Innovibe indexers in one shell.
 ─────────────────────────────────────────────────────────────────────
 
   Federal V2 importer:
@@ -64,6 +75,12 @@ cat <<'B'
     php src/index.php                   # index pending jobs + purge
     php src/index.php -r                # recreate indexes + reindex all
     php src/index.php -o                # close/reopen to reload synonyms
+    php src/index.php -d                # diff ES vs Jobs (debug)
+
+  Innovibe indexer (staging → Elasticsearch):
+    cd /app/workbc-indexers-innovibe-v2
+    php src/index.php                   # index pending jobs + purge
+    php src/index.php -r                # recreate indexes + reindex all
     php src/index.php -d                # diff ES vs Jobs (debug)
 
   After manually running an import you usually need to re-index.


### PR DESCRIPTION
…rs.Innovibe.V2)

Port the stage-2 external-jobs indexer (WorkBC.Indexers.Wanted + WorkBC.ElasticSearch.Indexing JSON path) to a self-contained PHP 8.3 CLI app, built from the Federal indexer template. Reads ImportedJobsWanted (non-federal), builds the Elasticsearch document from the Innovibe JSON, PUTs it to jobs_en, applies the publishable-gate, then purges expired and orphaned docs.

Verified byte-for-byte equivalent to the .NET indexer: 0/14678 document diffs in jobs_en over the local devworkbc dataset (same 45 publishable-gate rejects, same purge and --debug output).

Scope: JSON only — Innovibe is the sole external-jobs source and its payloads are always JSON, so the legacy TalentNeuron XML branch is dropped.

- InnovibeDocumentMapper: JSON → ES document (BC-preferred location, city/region disambiguation, salary annual conversion, employmentType → hours/period, 3-strategy education mapping, NOC 2021 from nocMatches, title cleanup, ExternalSource, SalarySort).
- InnovibeIndexService: index loop, IsPublishable gate + FlushRejected (ExpiredJobs upsert + Jobs.IsActive=false), single-index PUT with retry, UpdateIds (correct table), purge (expired + orphan sweep), debug.
- ElasticClient.getFederalJobIds generalized to getJobIdsBySource.

Parity details captured for the Wanted path: naive (no-offset) date format; emit federal-only value-type defaults (WorkHours/EmployerTypeId/Is* flags); EmploymentTerms as {}; salary rounded to 4 dp; lat/lon via json_encode for full precision; unicode-trim titles.

Deployment: baked into php-cli.Dockerfile (cli2) at /app/workbc-indexers-innovibe-v2; added indexers-innovibe-v2 to docker-compose(.linux-dev); build*.yml now tag/push the PHP image as jb-indexers-wanted so the CronJob wanted-indexer container (IMAGE7) runs PHP with no deploy-workflow change.