### PR TITLE
Apply June 2026 minimum wage increase ($18.25) and handle DAY salary units

### DIFF
--- a/src/WorkBC.Importers.Federal.V2/src/Xml/XmlJobMapper.php
+++ b/src/WorkBC.Importers.Federal.V2/src/Xml/XmlJobMapper.php
@@ -56,7 +56,8 @@ final class XmlJobMapper
     private const MAX_HOURLY_RATE = 2500.0;
     private const MAX_WEEKLY_SALARY = 100000.0;
     private const MAX_YEARLY_SALARY = 5000000.0;
-    private const MINIMUM_WAGE_FALLBACK = 17.40;
+    // B.C. general minimum wage effective June 1, 2026.
+    private const MINIMUM_WAGE_FALLBACK = 18.25;
 
     /** Matches WorkBC.Shared.Constants.General.DefaultWantedJobExpiryDays. */
     private const DEFAULT_EXPIRY_DAYS = 90;

--- a/src/WorkBC.Importers.Innovibe/src/Service/JobImportService.php
+++ b/src/WorkBC.Importers.Innovibe/src/Service/JobImportService.php
@@ -22,10 +22,12 @@ final class JobImportService
     // the same rules. A job is rejected when its hourly-equivalent wage is below
     // 90% of the admin-configured minimum wage (shared.settings.minimumWage).
     private const WEEKLY_WORK_HOURS     = 40.0;
+    private const DAILY_WORK_HOURS      = 8.0;
     private const WEEKS_PER_YEAR        = 52;
     private const MAX_HOURLY_RATE       = 2500.0;
     private const MAX_YEARLY_SALARY     = 5000000.0;
-    private const MINIMUM_WAGE_FALLBACK = 17.40;
+    // B.C. general minimum wage effective June 1, 2026.
+    private const MINIMUM_WAGE_FALLBACK = 18.25;
 
     private int $fetched  = 0;
     private int $inserted = 0;
@@ -99,7 +101,7 @@ final class JobImportService
      * Returns false when the job's wage is below the minimum-wage threshold.
      *
      * The value is normalised to an hourly rate using salaryUnitText (HOUR /
-     * WEEK / MONTH / YEAR) and compared against 90% of the admin minimum wage —
+     * DAY / WEEK / MONTH / YEAR) and compared against 90% of the admin minimum wage —
      * matching the 0.9 * minWage hourly rule the Federal importer applies. The
      * lowest advertised figure (salaryMin, else salaryValue, else salaryMax) is
      * used so a range is judged by its floor. Jobs with no usable/positive
@@ -114,6 +116,7 @@ final class JobImportService
 
         $hourly = match (strtoupper((string) ($job['salaryUnitText'] ?? ''))) {
             'HOUR'  => (float) $salary,
+            'DAY'   => (float) $salary / self::DAILY_WORK_HOURS,
             'WEEK'  => (float) $salary / self::WEEKLY_WORK_HOURS,
             'MONTH' => (float) $salary * 12 / (self::WEEKLY_WORK_HOURS * self::WEEKS_PER_YEAR),
             'YEAR'  => (float) $salary / (self::WEEKLY_WORK_HOURS * self::WEEKS_PER_YEAR),
@@ -582,6 +585,7 @@ final class JobImportService
         $salaryUnit = strtoupper($j['salaryUnitText'] ?? '');
         $annualMultiplier = match ($salaryUnit) {
             'HOUR'  => 2080,   // 40 hrs/week × 52 weeks
+            'DAY'   => 260,    // 5 days/week × 52 weeks
             'WEEK'  => 52,
             'MONTH' => 12,
             default => 1,      // YEAR or unknown

--- a/src/WorkBC.Indexers.Innovibe.V2/src/Json/InnovibeDocumentMapper.php
+++ b/src/WorkBC.Indexers.Innovibe.V2/src/Json/InnovibeDocumentMapper.php
@@ -201,6 +201,7 @@ final class InnovibeDocumentMapper
         if ($salary !== null && $salary >= 0.01) {
             $multiplier = match ($salaryUnit) {
                 'HOUR' => 2080.0,
+                'DAY' => 260.0,
                 'WEEK' => 52.0,
                 'MONTH' => 12.0,
                 default => 1.0,

--- a/src/WorkBC.Tests/Fixtures/SystemSettingsFixture.cs
+++ b/src/WorkBC.Tests/Fixtures/SystemSettingsFixture.cs
@@ -10,7 +10,7 @@ namespace WorkBC.Tests.Fixtures
         public static List<SystemSetting> systemSetting =>
          new List<SystemSetting>
             {
-                new SystemSetting { Name="shared.settings.minimumWage", Value="17.85", Description="This is the minimum wage value that is used to filter data coming from the job bank.", FieldType= SystemSettingFieldType.SingleLineText, ModifiedByAdminUserId= 1, DateUpdated= DateTime.Now, DefaultValue="17.85"},
+                new SystemSetting { Name="shared.settings.minimumWage", Value="18.25", Description="This is the minimum wage value that is used to filter data coming from the job bank.", FieldType= SystemSettingFieldType.SingleLineText, ModifiedByAdminUserId= 1, DateUpdated= DateTime.Now, DefaultValue="18.25"},
                 new SystemSetting { Name="shared.settings.defaultSearchRadius", Value="15", Description="Default radius (km) for location searches. Valid values are 10, 15, 25, 50, 75 or 100. If you enter an invalid value then 15 will be used instead.", FieldType= SystemSettingFieldType.Number, ModifiedByAdminUserId= 1, DateUpdated= DateTime.Now, DefaultValue="15"}
             };
 


### PR DESCRIPTION
## Summary

B.C.'s general minimum wage increased from $17.85 to $18.25/hr on June 1, 2026. The admin setting (`shared.settings.minimumWage`) has already been updated to 18.25 via the JB Admin portal; this PR aligns the code with it. Jobs whose hourly-equivalent wage is below 90% of the configured minimum (0.9 × 18.25 = $16.425) are excluded at import time.

## Changes

- **`WorkBC.Importers.Innovibe/src/Service/JobImportService.php`**
  - `MINIMUM_WAGE_FALLBACK` 17.40 → 18.25 (fallback only applies when the `SystemSettings` row is missing — the DB value remains authoritative).
  - Added a `DAY` arm (`salary / 8`) to the min-wage gate's hourly normalisation. Previously day-rate salaries fell through to the yearly default (÷ 2080), so legitimate day-rate postings (e.g. on-call teachers at ~$310/day ≈ $39/hr) were wrongly rejected — verified against 14,723 real `ImportedJobsWanted` rows, where 56 of 57 day-rate jobs were being skipped.
  - Added `DAY → 260` annual multiplier so day-rate jobs get a correct `SalarySummary` instead of e.g. "$310 annually".
- **`WorkBC.Indexers.Innovibe.V2/src/Json/InnovibeDocumentMapper.php`** — same `DAY → 260` multiplier for the ES `Salary`/`SalarySummary` fields.
- **`WorkBC.Importers.Federal.V2/src/Xml/XmlJobMapper.php`** — `MINIMUM_WAGE_FALLBACK` 17.40 → 18.25.
- **`WorkBC.Tests/Fixtures/SystemSettingsFixture.cs`** — fixture seed 17.85 → 18.25.

## Notes for reviewers / deployment

- The min-wage exclusion gate itself already exists on `ams` (a9b2508); this PR updates the constants and fixes the DAY-unit gap.
- Jobs imported before the gate existed (or under $17.85) are not touched by importer code — a one-off backfill (expire staged Innovibe jobs below the new threshold) needs to run against the DB separately.
- Requires rebuild/redeploy of the Innovibe importer, Federal importer, and `jb-indexers-wanted` images. To refresh salary display on existing day-rate jobs: `UPDATE "ImportedJobsWanted" SET "ReIndexNeeded" = TRUE WHERE upper("JobPostEnglish"::jsonb->>'salaryUnitText') = 'DAY';`
- Federal indexer's known min-wage no-op (`.All()` bug replica in `FederalDocumentMapper`) is intentionally untouched — that belongs to the WBCAMS-2046 rework.
- `php -l` passes on all touched PHP files.

Related: WBCAMS-1958, WBCAMS-2046