### PR TITLE
Give hidden checkbox inputs a real 16px hit box so voice control can click them

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/icon/svgIcon.component.scss
+++ b/src/WorkBC.Web/ClientApp/projects/jb-lib/src/lib/components/icon/svgIcon.component.scss
@@ -44,6 +44,14 @@
 
 ::ng-deep input[type="checkbox"] {
   position: absolute;
+  // The Drupal host theme (workbc-main _job_board.scss) hides these native
+  // inputs inside app-root with `appearance:none; opacity:0; width:0`, which
+  // leaves voice control (UIA) no hit box to target. Keep a box matching the
+  // 16px .checkbox-icons artwork; !important out-ranks the theme's
+  // higher-specificity `app-root input[type=checkbox]` rule.
+  width: 16px !important;
+  height: 16px !important;
+  margin: 0 !important;
 
   & + .checkbox-icons, & + app-jb-checkbox .checkbox-icons {
     display: inline;
@@ -51,6 +59,11 @@
     /*top: 2px;*/
     z-index: -1;
     color: #234075;
+    // Decorative overlay only — it must never swallow the mouseup of a click
+    // aimed at the input: the :focus z-index bump (e.g. job-seeker register
+    // outline) raises it above the input mid-click, which retargets the click
+    // to the parent div and cancels the checkbox toggle.
+    pointer-events: none !important;
 
     lib-svg-icon:first-child {
       display: inline-flex;


### PR DESCRIPTION
## Problem (WBCAMS voice-control a11y ticket)
Windows Voice Access cannot target the checkboxes on `/account#/login` and `/account#/register`. Verified on the live dev page: the Drupal host theme (`workbc-main` `_job_board.scss`) hides every native input inside `app-root` with `appearance:none; opacity:0; width:0`, collapsing them to a **0×0** box. The earlier aria-label/aria-hidden fixes gave the checkbox a proper accessible *name*, but voice control also needs a real bounding box to click — and there was none.

A second issue: the register page's focus outline rule (`input:focus + .checkbox-icons { z-index: 0 }`) raises the decorative SVG overlay above the input mid-click, so the mouseup retargets to the parent div and the toggle is cancelled.

## Fix (jb-lib `svgIcon.component.scss`)
- Force a `16px × 16px` hit box on the (invisible) native checkbox, matching the SVG artwork it overlays (`!important` to out-rank the theme's higher-specificity `app-root input` rule).
- `pointer-events: none` on the decorative `.checkbox-icons` overlay so it can never swallow clicks aimed at the input.

Companion root-cause fix in `bcgov/workbc-main` theme CSS (same 16px box + pointer-events) — either side alone fixes the pages; both are being changed for defense in depth.

## Verification
Headless-Chromium against the live dev pages with the fixed CSS applied:
- `#isYouth` / `#JobSeekerIsApprenticeship` (register) and `#staySignedIn` (login): bounds go 0×0 → 16×16, and real mouse clicks at the input's bounds toggle reliably (`false → true → false → true`).
- Before the fix, Playwright refused to click the inputs at all ("element is not visible") — matching the QA failure "We can't find check box on youth".