### PR TITLE
Make the post-registration focus landing visible on the thank-you container

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-account/src/app/register/thank-you/thank-you.component.scss
+++ b/src/WorkBC.Web/ClientApp/projects/jb-account/src/app/register/thank-you/thank-you.component.scss
@@ -4,8 +4,12 @@
     background: #ffffff;
     padding-bottom: 20px;
 
+    // The container receives programmatic focus after registration
+    // (tabindex="-1"); the outline must be visible so sighted users —
+    // and QA watching NVDA — can see focus land on the new content.
     &:focus {
-      outline: none;
+      outline: 2px solid #234075;
+      outline-offset: -2px;
     }
 
     @media(min-width: 940px) {


### PR DESCRIPTION
## Ticket: [WEP] Register page - Accessibility - Screen reader when trying to register

## Investigation (headless Chromium against live dev, register API mocked — no accounts created)
The existing focus management **already works on dev**:
- `document.activeElement` lands on the `.thank-you` container immediately after Register and stays there (sampled up to 1.5s)
- Tab moves to the **Resend activation email** button — the first interactive element in the new content, exactly as the ticket's expected result requires
- NVDA announcing *"Thanks for registering!"* (confirmed by QA on Jul 9) is the container focus + `role=status` live region doing their job

The one real defect: the container was styled `&:focus { outline: none }`, so the focus move is **invisible**. QA watching the video sees nothing change and reports "focus does not move".

## Fix
Show a visible 2px outline (app navy, inset) on the thank-you container while it holds focus. It only ever receives focus programmatically after successful registration, so the outline appears exactly once, on the new content area.