### PR TITLE
Out-rank Bootstrap's outline suppression on the focused thank-you container

### DIFF
--- a/src/WorkBC.Web/ClientApp/projects/jb-account/src/app/register/thank-you/thank-you.component.scss
+++ b/src/WorkBC.Web/ClientApp/projects/jb-account/src/app/register/thank-you/thank-you.component.scss
@@ -1,16 +1,19 @@
+// The container receives programmatic focus after registration
+// (tabindex="-1"); the outline must be visible so sighted users —
+// and QA watching NVDA — can see focus land on the new content.
+// Bootstrap's reboot ships `app-root [tabindex="-1"]:focus:not(:focus-visible)
+// { outline: 0 !important }` (specificity 0,3,1), which silently suppressed
+// the outline: this selector is (0,3,2) with !important so it out-ranks it.
+::ng-deep app-root app-thank-you .thank-you[tabindex="-1"]:focus {
+  outline: 2px solid #234075 !important;
+  outline-offset: -2px;
+}
+
 ::ng-deep app-thank-you {
 
   .thank-you {
     background: #ffffff;
     padding-bottom: 20px;
-
-    // The container receives programmatic focus after registration
-    // (tabindex="-1"); the outline must be visible so sighted users —
-    // and QA watching NVDA — can see focus land on the new content.
-    &:focus {
-      outline: 2px solid #234075;
-      outline-offset: -2px;
-    }
 
     @media(min-width: 940px) {
       padding: 40px 0 80px 0;

--- a/src/WorkBC.Web/ClientApp/projects/jb-account/src/app/register/thank-you/thank-you.component.scss
+++ b/src/WorkBC.Web/ClientApp/projects/jb-account/src/app/register/thank-you/thank-you.component.scss
@@ -1,9 +1,3 @@
-// The container receives programmatic focus after registration
-// (tabindex="-1"); the outline must be visible so sighted users —
-// and QA watching NVDA — can see focus land on the new content.
-// Bootstrap's reboot ships `app-root [tabindex="-1"]:focus:not(:focus-visible)
-// { outline: 0 !important }` (specificity 0,3,1), which silently suppressed
-// the outline: this selector is (0,3,2) with !important so it out-ranks it.
 ::ng-deep app-root app-thank-you .thank-you[tabindex="-1"]:focus {
   outline: 2px solid #234075 !important;
   outline-offset: -2px;


### PR DESCRIPTION
## Found during live verification of #361 on dev
The merged focus outline computes to `0px none` on the real page. The SPA's own `bootstrap.min.css` reboot contains:

```css
app-root [tabindex="-1"]:focus:not(:focus-visible) { outline: 0 !important; }
```

Programmatic `.focus()` on the container after a mouse-driven Register click is **not** `:focus-visible`, so this rule matches — and at specificity (0,3,1) + `!important` it beats the previous (0,2,1) non-important rule. Only `outline-offset` and `outline-color` survived; width/style were zeroed, so nothing was visible. (Same CSS-cascade class of bug as the checkbox hit-box issue.)

## Fix
Selector `app-root app-thank-you .thank-you[tabindex="-1"]:focus` — specificity (0,3,2) — with `!important`, which deterministically out-ranks the Bootstrap rule regardless of stylesheet order.

## Verification (headless Chromium, live dev page, register API mocked)
- Injecting exactly this rule: computed style while focused = `outline: 2px solid rgb(35, 64, 117)`, `outline-offset: -2px` ✓
- Focus behaviour unchanged and re-confirmed on live dev: `activeElement` = `.thank-you` container, Tab → "Resend activation email" button
- Checkbox fixes (#360 + workbc-main#881) also re-verified live after deploy: all three checkboxes 16×16, midpoint hit-test = input, click sequences toggle `false→true→false→true`